### PR TITLE
Add own modal component

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/vue-fontawesome": "^3.0.0-4",
     "axios": "^0.23.0",
+    "body-scroll-lock": "^4.0.0-beta.0",
     "core-js": "^3.6.5",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
@@ -29,11 +30,12 @@
     "tippy.js": "^6.3.2",
     "ua-parser-js": "^1.0.2",
     "vue": "^3.0.0",
-    "vue-final-modal": "^3.4.3",
     "vue-router": "^4.0.0-0",
-    "vuex": "^4.0.0-0"
+    "vuex": "^4.0.0-0",
+    "wicg-inert": "^3.1.1"
   },
   "devDependencies": {
+    "@types/body-scroll-lock": "^3.1.0",
     "@types/jest": "^24.0.19",
     "@types/jest-axe": "^3.5.3",
     "@types/js-yaml": "^4.0.3",

--- a/src/components/AppInput.vue
+++ b/src/components/AppInput.vue
@@ -2,12 +2,7 @@
   <label class="input">
     <div v-if="title" class="title">
       {{ title }}
-      <AppIcon
-        v-if="required"
-        icon="asterisk"
-        class="asterisk"
-        v-tooltip="'Required field'"
-      />
+      <AppIcon v-if="required" icon="asterisk" class="asterisk" />
     </div>
     <textarea
       v-if="multi"

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,38 +1,137 @@
 <template>
-  <VueFinalModal
-    :modelValue="modelValue"
-    @update:modelValue="$emit('update:modelValue', $event.value)"
-    classes="modal-container"
-    content-class="modal-content"
-    :focus-trap="true"
-    :esc-to-close="true"
-    v-slot="{ close }"
-  >
-    <!-- only render slot if modal visible to force remount on open -->
-    <slot v-if="modelValue" />
-    <AppButton
-      class="close"
-      icon="times"
-      @click="close"
-      v-tooltip="'Close dialog (esc)'"
-    />
-  </VueFinalModal>
+  <teleport to="body">
+    <transition name="fade">
+      <div
+        v-if="modelValue"
+        class="overlay"
+        @mousedown="close"
+        @touchstart="close"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="label"
+      >
+        <div ref="modal" class="modal" @mousedown.stop @touchstart.stop>
+          <AppButton
+            class="close"
+            icon="times"
+            @click="close"
+            v-tooltip="'Close dialog (esc)'"
+          />
+          <slot />
+        </div>
+      </div>
+    </transition>
+  </teleport>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, nextTick } from "vue";
+import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock";
 
 // modal component with arbitrary content
 export default defineComponent({
   props: {
     // open state
     modelValue: Boolean,
+    // modal aria label
+    label: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      originalFocus: null as HTMLElement | null,
+    };
   },
   emits: ["update:modelValue"],
+  methods: {
+    // update model value to close modal
+    close() {
+      this.$emit("update:modelValue", false);
+    },
+    // on key down
+    keyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") this.close();
+    },
+  },
+  mounted() {
+    // global keydown listener
+    window.addEventListener("keydown", this.keyDown);
+  },
+  updated() {
+    // modal element
+    const modal = this.$refs.modal as HTMLElement;
+    // rest of app besides modal
+    const app = document.querySelector("#app");
+
+    // if modal just opened
+    if (this.modelValue) {
+      // hide for screen readers
+      app?.setAttribute("aria-hidden", "true");
+      // disable focus
+      app?.setAttribute("inert", "true");
+      // disable body scroll
+      disableBodyScroll(modal);
+      // focus first focusable element in modal
+      const query = "input, textarea, button, select";
+      const focusable = modal.querySelector(query) as HTMLElement;
+      focusable?.focus();
+    }
+  },
+  beforeUpdate() {
+    // modal element
+    const modal = this.$refs.modal as HTMLElement;
+    // rest of app besides modal
+    const app = document.querySelector("#app");
+
+    // if modal about to be opened
+    if (this.modelValue) {
+      this.originalFocus = document.activeElement as HTMLElement;
+    }
+    // if modal about to be closed
+    else {
+      // show for screen readers
+      app?.removeAttribute("aria-hidden");
+      // enable focus
+      app?.removeAttribute("inert");
+      // enable body scroll
+      enableBodyScroll(modal);
+      // restore focus to what had focus before modal opened
+      nextTick(() => this.originalFocus?.focus());
+    }
+  },
+  beforeUnmount() {
+    // global keydown listener
+    window.removeEventListener("keydown", this.keyDown);
+  },
 });
 </script>
 
 <style lang="scss" scoped>
+.overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: #000000c0;
+  z-index: 99;
+}
+
+.modal {
+  position: relative;
+  max-width: min(800px, calc(100vw - 80px));
+  max-height: calc(100vh - 80px);
+  padding: 40px;
+  background: $white;
+  overflow-y: auto;
+  z-index: 100;
+}
+
 // close button
 .close {
   position: absolute;
@@ -48,26 +147,4 @@ export default defineComponent({
 }
 </style>
 
-<style lang="scss">
-// style overlay under modal
-.vfm--overlay {
-  background: #000000a0 !important;
-}
-
-// center modal in screen
-.modal-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-// style modal itself
-.modal-content {
-  position: relative;
-  max-width: min(800px, calc(100vw - 80px));
-  max-height: calc(100vh - 80px);
-  padding: 40px;
-  background: $white;
-  overflow-y: auto;
-}
-</style>
+<style lang="scss"></style>

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -28,7 +28,7 @@
 import { defineComponent, nextTick } from "vue";
 import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock";
 
-// modal component with arbitrary content
+// basic modal component with arbitrary content
 export default defineComponent({
   props: {
     // open state

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -146,5 +146,3 @@ export default defineComponent({
   }
 }
 </style>
-
-<style lang="scss"></style>

--- a/src/components/TheFloatButtons.vue
+++ b/src/components/TheFloatButtons.vue
@@ -18,7 +18,7 @@
         v-tooltip="'Give us feedback on this page!'"
       />
     </transition>
-    <AppModal v-model="showModal">
+    <AppModal v-model="showModal" label="Feedback form">
       <AppFeedbackForm :modal="true" />
     </AppModal>
   </div>

--- a/src/global/plugins.ts
+++ b/src/global/plugins.ts
@@ -1,8 +1,7 @@
 import router from "@/router";
 import store from "@/store";
-import VueFinalModal from "vue-final-modal";
 
 // list of global plugins
-const plugins = [router, store, VueFinalModal];
+const plugins = [router, store];
 
 export default plugins;

--- a/src/global/styles.scss
+++ b/src/global/styles.scss
@@ -144,7 +144,7 @@ strong {
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.5s ease;
+  transition: opacity 0.2s ease;
 }
 
 .fade-enter-to,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import components from "@/global/components";
 import mixins from "@/global/mixins";
 import plugins from "@/global/plugins";
 import directives from "@/global/directives";
+import "wicg-inert";
 
 // create main app object
 let app = createApp(App);

--- a/tests/e2e/specs/feedback.js
+++ b/tests/e2e/specs/feedback.js
@@ -1,0 +1,32 @@
+it("Feedback form can open and close", () => {
+  // setup
+  cy.visit("/");
+
+  // get open feedback form button
+  cy.get("button[aria-label*='feedback']").first().as("open");
+
+  // open feedback form modal
+  cy.get("@open").click();
+
+  // see if modal has opened and shown feedback form correctly
+  cy.get(".modal").contains("Feedback Form").should("be.visible");
+
+  // click in middle of modal, which should not close modal
+  cy.get(".modal").first().click();
+  cy.get(".modal").should("be.visible");
+
+  // click in overlay in corner, which should close modal
+  cy.get(".overlay").first().click(10, 10);
+  cy.get(".modal").should("not.be.visible");
+
+  // reopen and make sure pressing esc closes
+  cy.get("@open").click();
+  cy.window().trigger("keydown", { key: "Escape" });
+  cy.window().trigger("keypress", { key: "Escape" });
+  cy.get(".modal").should("not.be.visible");
+
+  // reopen and make sure x button closes
+  cy.get("@open").click();
+  cy.get(".modal button").first().click(); // close button should always be first button in dom order
+  cy.get(".modal").should("not.be.visible");
+});

--- a/tests/unit/AppHeading.test.ts
+++ b/tests/unit/AppHeading.test.ts
@@ -1,4 +1,3 @@
-import { sleep } from "./../../src/util/debug";
 import { flushPromises, mount } from "@vue/test-utils";
 import AppHeadings from "./AppHeadings.vue";
 import { mountOptions } from "../setup";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/body-scroll-lock@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.0.tgz#435f6abf682bf58640e1c2ee5978320b891970e7"
+  integrity sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==
+
 "@types/connect-history-api-fallback@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -2920,6 +2925,11 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+body-scroll-lock@^4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
+  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
 
 bonjour@^3.5.0:
   version "3.5.0"
@@ -11576,11 +11586,6 @@ vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.10.0:
     lodash "^4.17.21"
     semver "^6.3.0"
 
-vue-final-modal@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/vue-final-modal/-/vue-final-modal-3.4.3.tgz#8fdf56da8a03cdf9e54bcaeb8293a93f88758915"
-  integrity sha512-sp6M09oXGcRM3d3Jr80UywWx4C9I18nH/549fgNrs8qbCcw+DJc8QSUFkJ91lqWndGQ1q5rYen4i4IIrpHPVYA==
-
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
@@ -11935,6 +11940,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wicg-inert@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.1.1.tgz#b033fd4fbfb9e3fd709e5d84becbdf2e06e5c229"
+  integrity sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
closes monarch-initiative/monarch-api#139 

- replaces `vue-final-modal` with own component
- adds e2e test for opening and closing feedback form