### PR TITLE
Misc tweaks

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "pluginsFile": "tests/e2e/plugins/index.js"
+  "pluginsFile": "tests/e2e/plugins/index.js",
+  "video": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "monarch-ui",
   "version": "0.1.0",
-  "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
@@ -68,7 +67,6 @@
     "raw-loader": "^4.0.2",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
-    "sitemap-webpack-plugin": "^1.1.1",
     "tslib": "^2.3.1",
     "typescript": "^4.4.4",
     "vue-jest": "^5.0.0-0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit /unit",
-    "test:e2e": "vue-cli-service test:e2e --headless",
+    "test:e2e": "DEBUG=cypress:* vue-cli-service test:e2e --headless",
     "lint": "vue-cli-service lint && prettier --check ./src/**/*.yaml",
     "fresh": "yarn cache clean && rm -rf node_modules && yarn install",
     "test": "yarn test:lint && yarn test:unit && yarn test:e2e && yarn test:axe",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,6 +9,7 @@
   <url>
     <!-- home -->
     <loc>https://monarchinitiative.org/</loc>
+    <loc>https://monarchinitiative.org/home</loc>
 
     <!-- explore -->
     <loc>https://monarchinitiative.org/explore</loc>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+  xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
+>
+  <url>
+    <!-- home -->
+    <loc>https://monarchinitiative.org/</loc>
+
+    <!-- explore -->
+    <loc>https://monarchinitiative.org/explore</loc>
+
+    <!-- tools -->
+    <loc>https://monarchinitiative.org/tools</loc>
+
+    <!-- about -->
+    <loc>https://monarchinitiative.org/about</loc>
+    <loc>https://monarchinitiative.org/cite</loc>
+    <loc>https://monarchinitiative.org/sources</loc>
+    <loc>https://monarchinitiative.org/team</loc>
+    <loc>https://monarchinitiative.org/publications</loc>
+    <loc>https://monarchinitiative.org/terms</loc>
+
+    <!-- help -->
+    <loc>https://monarchinitiative.org/help</loc>
+    <loc>https://monarchinitiative.org/feedback</loc>
+  </url>
+</urlset>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -39,6 +39,10 @@ footer {
 a {
   color: $white;
   transition: opacity $fast;
+
+  &:hover {
+    opacity: 0.5;
+  }
 }
 
 .social {
@@ -47,15 +51,8 @@ a {
 }
 
 .social a {
-  padding: 10px;
-}
-
-.social:hover a {
-  opacity: 0.2;
-}
-
-.social:hover a:hover {
-  opacity: 1;
+  margin: 5px;
+  padding: 5px;
 }
 
 .license {

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <header :data-home="home">
     <!-- header background visualization -->
-    <TheViz />
+    <TheNexus />
 
     <!-- title bar -->
     <div class="title">
@@ -70,12 +70,12 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import TheViz from "./TheViz.vue";
+import TheNexus from "./TheNexus.vue";
 import Logo from "@/assets/Logo.vue";
 
 export default defineComponent({
   components: {
-    TheViz,
+    TheNexus,
     Logo,
   },
   data() {
@@ -214,20 +214,29 @@ nav {
 }
 
 .link {
+  position: relative;
   width: 100%;
-  padding: 15px;
+  margin: 5px;
+  padding: 10px;
   color: $white;
   text-decoration: none;
   text-align: center;
-  transition: opacity $fast;
-}
 
-nav:hover .link {
-  opacity: 0.2;
-}
+  &:after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    right: 50%;
+    bottom: 0;
+    height: 2px;
+    background: $white;
+    transition: left $fast, right $fast;
+  }
 
-nav:hover .link:hover {
-  opacity: 1;
+  &:hover:after {
+    left: 5px;
+    right: 5px;
+  }
 }
 
 @media (max-width: $wrap) {

--- a/src/components/TheNexus.vue
+++ b/src/components/TheNexus.vue
@@ -9,6 +9,7 @@ import {
   sin,
   cos,
   dist,
+  absMax,
   Point3d,
   Point2d,
   project,
@@ -134,8 +135,8 @@ const generate = debounce(() => {
 // move physics simulation one step
 const move = () => {
   // move 3d world rotation toward target rotation smoothly
-  rx += (rxTarget - rx) / 100;
-  ry += (ryTarget - ry) / 100;
+  rx += absMax((rxTarget - rx) / 100, 0.2);
+  ry += absMax((ryTarget - ry) / 100, 0.2);
 
   // for each dot
   for (const dot of dots) {
@@ -220,7 +221,7 @@ const rotate = (event: MouseEvent | TouchEvent) => {
 // fps
 window.setInterval(step, 1000 / 60);
 // how frequently field pulses
-window.setInterval(pulse, 5000);
+window.setInterval(pulse, 10000);
 
 // fun background visualization element behind header
 export default defineComponent({

--- a/src/global/tooltip.ts
+++ b/src/global/tooltip.ts
@@ -12,7 +12,7 @@ const mounted = (
   { value }: DirectiveBinding
 ): void => {
   if (value) {
-    tippy(element, { content: value });
+    tippy(element, { content: value, delay: 100, duration: 200 });
     element.setAttribute("aria-label", value);
   }
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,6 +31,7 @@ const redirect404 = (): string | void => {
 };
 
 // list of routes and corresponding components
+// CHECK PUBLIC/SITEMAP.XML AND KEEP IN SYNC
 export const routes: Array<RouteRecordRaw> = [
   {
     path: "/",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -63,6 +63,11 @@ export const routes: Array<RouteRecordRaw> = [
     component: Cite,
   },
   {
+    path: "/sources",
+    name: "Sources",
+    component: Sources,
+  },
+  {
     path: "/team",
     name: "Team",
     component: Team,
@@ -71,11 +76,6 @@ export const routes: Array<RouteRecordRaw> = [
     path: "/publications",
     name: "Publications",
     component: Publications,
-  },
-  {
-    path: "/sources",
-    name: "Sources",
-    component: Sources,
   },
   {
     path: "/terms",

--- a/src/router/sitemap.js
+++ b/src/router/sitemap.js
@@ -1,9 +1,0 @@
-// list of static paths to include in generated sitemap
-// gets imported to sitemap-webpack-plugin in vue.config.js
-module.exports = {
-  paths: ["/"],
-};
-
-// cannot get this automatically from router routes due to commonjs and esm
-// incompatibility, and because we want to add a long list of pre-selected
-// dynamic routes (e.g. cool diseases, genes, etc.)

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -8,6 +8,10 @@ export const sin = (degrees = 0): number =>
 export const cos = (degrees = 0): number =>
   Math.cos((2 * Math.PI * degrees) / 360);
 
+// absolute value limit
+export const absMax = (value = 0, limit = 0): number =>
+  Math.max(Math.min(value, limit), -limit);
+
 // STUFF ONLY USED FOR HEADER VISUALIZATION
 
 // point tuple types

--- a/src/views/about/About.vue
+++ b/src/views/about/About.vue
@@ -21,6 +21,12 @@
       subtitle="How to cite and attribute Monarch"
     />
     <AppTile
+      to="/sources"
+      icon="database"
+      title="Sources"
+      subtitle="Datasets, ontologies, and downloads"
+    />
+    <AppTile
       to="/team"
       icon="users"
       title="Team"
@@ -31,12 +37,6 @@
       icon="newspaper"
       title="Publications"
       subtitle="Monarch-related published works"
-    />
-    <AppTile
-      to="/sources"
-      icon="database"
-      title="Sources"
-      subtitle="Datasets, ontologies, and downloads"
     />
     <AppTile
       to="/terms"

--- a/src/views/help/Help.vue
+++ b/src/views/help/Help.vue
@@ -9,20 +9,20 @@
     <AppTile
       icon="comment"
       title="Feedback Form"
-      subtitle="Right here, no account required"
+      subtitle="Right here, no account required, one-way"
       to="/feedback"
     />
     <AppTile
       icon="comments"
       title="Help Desk"
-      subtitle="If you have a GitHub account"
+      subtitle="On GitHub, requires account, two-way"
       to="https://github.com/monarch-initiative/helpdesk"
     />
   </AppSection>
 
-  <!-- tutorials/faqs/etc -->
+  <!-- tutorials/faqs -->
   <AppSection>
-    <AppHeading>How to use Monarch</AppHeading>
+    <AppHeading>How to use this website</AppHeading>
     <AppGallery>
       <AppPlaceholder />
       <AppPlaceholder />
@@ -31,6 +31,11 @@
       <AppPlaceholder />
       <AppPlaceholder />
     </AppGallery>
+  </AppSection>
+
+  <!-- other help -->
+  <AppSection>
+    <AppHeading>How to use the rest of Monarch</AppHeading>
     <AppButton to="/tools" text="API and Tools" icon="tools" />
     <AppButton to="/sources" text="Ontologies and Datasets" icon="database" />
   </AppSection>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,18 +1,4 @@
-/* eslint @typescript-eslint/no-var-requires: "off" */
-const SitemapPlugin = require("sitemap-webpack-plugin").default;
-const { paths } = require("./src/router/sitemap.js");
-
-// webpack plugin to generate sitemap with app build
-const sitemapPlugin = new SitemapPlugin({
-  base: process.env.VUE_APP_URL,
-  paths,
-});
-
 module.exports = {
-  // add plugins
-  configureWebpack: {
-    plugins: [sitemapPlugin],
-  },
   // add extra file type loaders
   chainWebpack: (config) => {
     // markdown and raw text

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,11 +1534,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
-"@types/node@^14.14.28":
-  version "14.17.32"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.32.tgz#2ca61c9ef8c77f6fa1733be9e623ceb0d372ad96"
-  integrity sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==
-
 "@types/node@^14.14.31":
   version "14.17.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.33.tgz#011ee28e38dc7aee1be032ceadf6332a0ab15b12"
@@ -1568,13 +1563,6 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
-
-"@types/sax@^1.2.1":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.3.tgz#b630ac1403ebd7812e0bf9a10de9bf5077afb348"
-  integrity sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==
-  dependencies:
-    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.13.10"
@@ -2588,11 +2576,6 @@ arch@^2.1.1, arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
-
-arg@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.1.tgz#eb0c9a8f77786cad2af8ff2b862899842d7b6adb"
-  integrity sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -10526,25 +10509,6 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
-sitemap-webpack-plugin@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sitemap-webpack-plugin/-/sitemap-webpack-plugin-1.1.1.tgz#884b779b6cbe3a0a3def845506f6ac1f33b3e12f"
-  integrity sha512-ViKO1uIe7oUMJdjXX098eNRn/Yp04dajC2bmODXhy6qvmYtbBfauGQrir72u/WdMxIpOP0q5y07hyvB10py+OA==
-  dependencies:
-    schema-utils "^3.0.0"
-    sitemap "^6.0.0"
-    webpack-sources "^1.4.3"
-
-sitemap@^6.0.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-6.4.0.tgz#b4bc4edf36de742405a7572bc3e467ba484b852e"
-  integrity sha512-DoPKNc2/apQZTUnfiOONWctwq7s6dZVspxAZe2VPMNtoqNq7HgXRvlRnbIpKjf+8+piQdWncwcy+YhhTGY5USQ==
-  dependencies:
-    "@types/node" "^14.14.28"
-    "@types/sax" "^1.2.1"
-    arg "^5.0.0"
-    sax "^1.2.4"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -12013,7 +11977,7 @@ webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==


### PR DESCRIPTION
- make manual sitemap and get rid of webpack plugin to generate it
- rename header visualization to "the nexus"
- header and footer link css tweaks
- limit speed of rotation in nexus viz
- tooltip tweaks
- misc ordering and text changes
- turn off cypress video recording

After much experimenting and investigating -- looking through github and [stackoverflow issues](https://stackoverflow.com/questions/69665780/error-err-unsupported-esm-url-scheme-only-file-and-data-urls-are-supported-by), tutorials, [packages](https://github.com/TypeStrong/ts-node), and new package versions (e.g. `vue-cli: ^5.0.0-rc.1`) -- I couldn't find a way to have vue-cli and weback be able to load the existing array of `routes` in `src/router.index.ts`. There is trouble with loading module type (`import`/`export`, modern ES javascript), typescript, and special things like vue-cli's `@/folder` syntax, from node.

I've come to the conclusion that the best solution is to simply update the sitemap manually. That is essentially what I'm currently doing with `src/router/sitemap.js` and `sitemap-webpack-plugin`, but with unnecessary extra steps and complexity.