### PR TITLE
Associations table sorting/filtering and misc

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,118 +8,118 @@
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = "f0a916b13c8acc2b526a03a6d26df85f";
-const bypassHeaderName = "x-msw-bypass";
-const activeClientIds = new Set();
+const INTEGRITY_CHECKSUM = 'f0a916b13c8acc2b526a03a6d26df85f'
+const bypassHeaderName = 'x-msw-bypass'
+const activeClientIds = new Set()
 
-self.addEventListener("install", function () {
-  return self.skipWaiting();
-});
+self.addEventListener('install', function () {
+  return self.skipWaiting()
+})
 
-self.addEventListener("activate", async function (event) {
-  return self.clients.claim();
-});
+self.addEventListener('activate', async function (event) {
+  return self.clients.claim()
+})
 
-self.addEventListener("message", async function (event) {
-  const clientId = event.source.id;
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
-  const allClients = await self.clients.matchAll();
+  const allClients = await self.clients.matchAll()
 
   switch (event.data) {
-    case "KEEPALIVE_REQUEST": {
+    case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
-        type: "KEEPALIVE_RESPONSE",
-      });
-      break;
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
     }
 
-    case "INTEGRITY_CHECK_REQUEST": {
+    case 'INTEGRITY_CHECK_REQUEST': {
       sendToClient(client, {
-        type: "INTEGRITY_CHECK_RESPONSE",
+        type: 'INTEGRITY_CHECK_RESPONSE',
         payload: INTEGRITY_CHECKSUM,
-      });
-      break;
+      })
+      break
     }
 
-    case "MOCK_ACTIVATE": {
-      activeClientIds.add(clientId);
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
-        type: "MOCKING_ENABLED",
+        type: 'MOCKING_ENABLED',
         payload: true,
-      });
-      break;
+      })
+      break
     }
 
-    case "MOCK_DEACTIVATE": {
-      activeClientIds.delete(clientId);
-      break;
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
     }
 
-    case "CLIENT_CLOSED": {
-      activeClientIds.delete(clientId);
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 // Resolve the "master" client for the given event.
 // Client that issues a request doesn't necessarily equal the client
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMasterClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
-  if (client.frameType === "top-level") {
-    return client;
+  if (client.frameType === 'top-level') {
+    return client
   }
 
-  const allClients = await self.clients.matchAll();
+  const allClients = await self.clients.matchAll()
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === "visible";
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMasterClient(event);
-  const response = await getResponse(event, client, requestId);
+  const client = await resolveMasterClient(event)
+  const response = await getResponse(event, client, requestId)
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    (async function () {
-      const clonedResponse = response.clone();
+    ;(async function () {
+      const clonedResponse = response.clone()
       sendToClient(client, {
-        type: "RESPONSE",
+        type: 'RESPONSE',
         payload: {
           requestId,
           type: clonedResponse.type,
@@ -131,21 +131,21 @@ async function handleRequest(event, requestId) {
           headers: serializeHeaders(clonedResponse.headers),
           redirected: clonedResponse.redirected,
         },
-      });
-    })();
+      })
+    })()
   }
 
-  return response;
+  return response
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event;
-  const requestClone = request.clone();
-  const getOriginalResponse = () => fetch(requestClone);
+  const { request } = event
+  const requestClone = request.clone()
+  const getOriginalResponse = () => fetch(requestClone)
 
   // Bypass mocking when the request client is not active.
   if (!client) {
-    return getOriginalResponse();
+    return getOriginalResponse()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -153,29 +153,29 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return await getOriginalResponse();
+    return await getOriginalResponse()
   }
 
   // Bypass requests with the explicit bypass header
-  if (requestClone.headers.get(bypassHeaderName) === "true") {
-    const cleanRequestHeaders = serializeHeaders(requestClone.headers);
+  if (requestClone.headers.get(bypassHeaderName) === 'true') {
+    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
 
     // Remove the bypass header to comply with the CORS preflight check.
-    delete cleanRequestHeaders[bypassHeaderName];
+    delete cleanRequestHeaders[bypassHeaderName]
 
     const originalRequest = new Request(requestClone, {
       headers: new Headers(cleanRequestHeaders),
-    });
+    })
 
-    return fetch(originalRequest);
+    return fetch(originalRequest)
   }
 
   // Send the request to the client-side MSW.
-  const reqHeaders = serializeHeaders(request.headers);
-  const body = await request.text();
+  const reqHeaders = serializeHeaders(request.headers)
+  const body = await request.text()
 
   const clientMessage = await sendToClient(client, {
-    type: "REQUEST",
+    type: 'REQUEST',
     payload: {
       id: requestId,
       url: request.url,
@@ -193,31 +193,31 @@ async function getResponse(event, client, requestId) {
       bodyUsed: request.bodyUsed,
       keepalive: request.keepalive,
     },
-  });
+  })
 
   switch (clientMessage.type) {
-    case "MOCK_SUCCESS": {
+    case 'MOCK_SUCCESS': {
       return delayPromise(
         () => respondWithMock(clientMessage),
-        clientMessage.payload.delay
-      );
+        clientMessage.payload.delay,
+      )
     }
 
-    case "MOCK_NOT_FOUND": {
-      return getOriginalResponse();
+    case 'MOCK_NOT_FOUND': {
+      return getOriginalResponse()
     }
 
-    case "NETWORK_ERROR": {
-      const { name, message } = clientMessage.payload;
-      const networkError = new Error(message);
-      networkError.name = name;
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
 
       // Rejecting a request Promise emulates a network error.
-      throw networkError;
+      throw networkError
     }
 
-    case "INTERNAL_ERROR": {
-      const parsedBody = JSON.parse(clientMessage.payload.body);
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
 
       console.error(
         `\
@@ -228,54 +228,54 @@ ${parsedBody.location}
 This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
 `,
         request.method,
-        request.url
-      );
+        request.url,
+      )
 
-      return respondWithMock(clientMessage);
+      return respondWithMock(clientMessage)
     }
   }
 
-  return getOriginalResponse();
+  return getOriginalResponse()
 }
 
-self.addEventListener("fetch", function (event) {
-  const { request } = event;
-  const accept = request.headers.get("accept") || "";
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
 
   // Bypass server-sent events.
-  if (accept.includes("text/event-stream")) {
-    return;
+  if (accept.includes('text/event-stream')) {
+    return
   }
 
   // Bypass navigation requests.
-  if (request.mode === "navigate") {
-    return;
+  if (request.mode === 'navigate') {
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
-    return;
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
-  const requestId = uuidv4();
+  const requestId = uuidv4()
 
   return event.respondWith(
     handleRequest(event, requestId).catch((error) => {
-      if (error.name === "NetworkError") {
+      if (error.name === 'NetworkError') {
         console.warn(
           '[MSW] Successfully emulated a network error for the "%s %s" request.',
           request.method,
-          request.url
-        );
-        return;
+          request.url,
+        )
+        return
       }
 
       // At this point, any exception indicates an issue with the original request/response.
@@ -284,55 +284,55 @@ self.addEventListener("fetch", function (event) {
 [MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
         request.method,
         request.url,
-        `${error.name}: ${error.message}`
-      );
-    })
-  );
-});
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
 
 function serializeHeaders(headers) {
-  const reqHeaders = {};
+  const reqHeaders = {}
   headers.forEach((value, name) => {
     reqHeaders[name] = reqHeaders[name]
       ? [].concat(reqHeaders[name]).concat(value)
-      : value;
-  });
-  return reqHeaders;
+      : value
+  })
+  return reqHeaders
 }
 
 function sendToClient(client, message) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
-    client.postMessage(JSON.stringify(message), [channel.port2]);
-  });
+    client.postMessage(JSON.stringify(message), [channel.port2])
+  })
 }
 
 function delayPromise(cb, duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(cb()), duration);
-  });
+    setTimeout(() => resolve(cb()), duration)
+  })
 }
 
 function respondWithMock(clientMessage) {
   return new Response(clientMessage.payload.body, {
     ...clientMessage.payload,
     headers: clientMessage.payload.headers,
-  });
+  })
 }
 
 function uuidv4() {
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0;
-    const v = c == "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,118 +8,118 @@
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = 'f0a916b13c8acc2b526a03a6d26df85f'
-const bypassHeaderName = 'x-msw-bypass'
-const activeClientIds = new Set()
+const INTEGRITY_CHECKSUM = "f0a916b13c8acc2b526a03a6d26df85f";
+const bypassHeaderName = "x-msw-bypass";
+const activeClientIds = new Set();
 
-self.addEventListener('install', function () {
-  return self.skipWaiting()
-})
+self.addEventListener("install", function () {
+  return self.skipWaiting();
+});
 
-self.addEventListener('activate', async function (event) {
-  return self.clients.claim()
-})
+self.addEventListener("activate", async function (event) {
+  return self.clients.claim();
+});
 
-self.addEventListener('message', async function (event) {
-  const clientId = event.source.id
+self.addEventListener("message", async function (event) {
+  const clientId = event.source.id;
 
   if (!clientId || !self.clients) {
-    return
+    return;
   }
 
-  const client = await self.clients.get(clientId)
+  const client = await self.clients.get(clientId);
 
   if (!client) {
-    return
+    return;
   }
 
-  const allClients = await self.clients.matchAll()
+  const allClients = await self.clients.matchAll();
 
   switch (event.data) {
-    case 'KEEPALIVE_REQUEST': {
+    case "KEEPALIVE_REQUEST": {
       sendToClient(client, {
-        type: 'KEEPALIVE_RESPONSE',
-      })
-      break
+        type: "KEEPALIVE_RESPONSE",
+      });
+      break;
     }
 
-    case 'INTEGRITY_CHECK_REQUEST': {
+    case "INTEGRITY_CHECK_REQUEST": {
       sendToClient(client, {
-        type: 'INTEGRITY_CHECK_RESPONSE',
+        type: "INTEGRITY_CHECK_RESPONSE",
         payload: INTEGRITY_CHECKSUM,
-      })
-      break
+      });
+      break;
     }
 
-    case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId)
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId);
 
       sendToClient(client, {
-        type: 'MOCKING_ENABLED',
+        type: "MOCKING_ENABLED",
         payload: true,
-      })
-      break
+      });
+      break;
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId);
+      break;
     }
 
-    case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId)
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId);
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId
-      })
+        return client.id !== clientId;
+      });
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister()
+        self.registration.unregister();
       }
 
-      break
+      break;
     }
   }
-})
+});
 
 // Resolve the "master" client for the given event.
 // Client that issues a request doesn't necessarily equal the client
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMasterClient(event) {
-  const client = await self.clients.get(event.clientId)
+  const client = await self.clients.get(event.clientId);
 
-  if (client.frameType === 'top-level') {
-    return client
+  if (client.frameType === "top-level") {
+    return client;
   }
 
-  const allClients = await self.clients.matchAll()
+  const allClients = await self.clients.matchAll();
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible'
+      return client.visibilityState === "visible";
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id)
-    })
+      return activeClientIds.has(client.id);
+    });
 }
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMasterClient(event)
-  const response = await getResponse(event, client, requestId)
+  const client = await resolveMasterClient(event);
+  const response = await getResponse(event, client, requestId);
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const clonedResponse = response.clone()
+    (async function () {
+      const clonedResponse = response.clone();
       sendToClient(client, {
-        type: 'RESPONSE',
+        type: "RESPONSE",
         payload: {
           requestId,
           type: clonedResponse.type,
@@ -131,21 +131,21 @@ async function handleRequest(event, requestId) {
           headers: serializeHeaders(clonedResponse.headers),
           redirected: clonedResponse.redirected,
         },
-      })
-    })()
+      });
+    })();
   }
 
-  return response
+  return response;
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event
-  const requestClone = request.clone()
-  const getOriginalResponse = () => fetch(requestClone)
+  const { request } = event;
+  const requestClone = request.clone();
+  const getOriginalResponse = () => fetch(requestClone);
 
   // Bypass mocking when the request client is not active.
   if (!client) {
-    return getOriginalResponse()
+    return getOriginalResponse();
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -153,29 +153,29 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return await getOriginalResponse()
+    return await getOriginalResponse();
   }
 
   // Bypass requests with the explicit bypass header
-  if (requestClone.headers.get(bypassHeaderName) === 'true') {
-    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
+  if (requestClone.headers.get(bypassHeaderName) === "true") {
+    const cleanRequestHeaders = serializeHeaders(requestClone.headers);
 
     // Remove the bypass header to comply with the CORS preflight check.
-    delete cleanRequestHeaders[bypassHeaderName]
+    delete cleanRequestHeaders[bypassHeaderName];
 
     const originalRequest = new Request(requestClone, {
       headers: new Headers(cleanRequestHeaders),
-    })
+    });
 
-    return fetch(originalRequest)
+    return fetch(originalRequest);
   }
 
   // Send the request to the client-side MSW.
-  const reqHeaders = serializeHeaders(request.headers)
-  const body = await request.text()
+  const reqHeaders = serializeHeaders(request.headers);
+  const body = await request.text();
 
   const clientMessage = await sendToClient(client, {
-    type: 'REQUEST',
+    type: "REQUEST",
     payload: {
       id: requestId,
       url: request.url,
@@ -193,31 +193,31 @@ async function getResponse(event, client, requestId) {
       bodyUsed: request.bodyUsed,
       keepalive: request.keepalive,
     },
-  })
+  });
 
   switch (clientMessage.type) {
-    case 'MOCK_SUCCESS': {
+    case "MOCK_SUCCESS": {
       return delayPromise(
         () => respondWithMock(clientMessage),
-        clientMessage.payload.delay,
-      )
+        clientMessage.payload.delay
+      );
     }
 
-    case 'MOCK_NOT_FOUND': {
-      return getOriginalResponse()
+    case "MOCK_NOT_FOUND": {
+      return getOriginalResponse();
     }
 
-    case 'NETWORK_ERROR': {
-      const { name, message } = clientMessage.payload
-      const networkError = new Error(message)
-      networkError.name = name
+    case "NETWORK_ERROR": {
+      const { name, message } = clientMessage.payload;
+      const networkError = new Error(message);
+      networkError.name = name;
 
       // Rejecting a request Promise emulates a network error.
-      throw networkError
+      throw networkError;
     }
 
-    case 'INTERNAL_ERROR': {
-      const parsedBody = JSON.parse(clientMessage.payload.body)
+    case "INTERNAL_ERROR": {
+      const parsedBody = JSON.parse(clientMessage.payload.body);
 
       console.error(
         `\
@@ -228,54 +228,54 @@ ${parsedBody.location}
 This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
 `,
         request.method,
-        request.url,
-      )
+        request.url
+      );
 
-      return respondWithMock(clientMessage)
+      return respondWithMock(clientMessage);
     }
   }
 
-  return getOriginalResponse()
+  return getOriginalResponse();
 }
 
-self.addEventListener('fetch', function (event) {
-  const { request } = event
-  const accept = request.headers.get('accept') || ''
+self.addEventListener("fetch", function (event) {
+  const { request } = event;
+  const accept = request.headers.get("accept") || "";
 
   // Bypass server-sent events.
-  if (accept.includes('text/event-stream')) {
-    return
+  if (accept.includes("text/event-stream")) {
+    return;
   }
 
   // Bypass navigation requests.
-  if (request.mode === 'navigate') {
-    return
+  if (request.mode === "navigate") {
+    return;
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return
+  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    return;
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return
+    return;
   }
 
-  const requestId = uuidv4()
+  const requestId = uuidv4();
 
   return event.respondWith(
     handleRequest(event, requestId).catch((error) => {
-      if (error.name === 'NetworkError') {
+      if (error.name === "NetworkError") {
         console.warn(
           '[MSW] Successfully emulated a network error for the "%s %s" request.',
           request.method,
-          request.url,
-        )
-        return
+          request.url
+        );
+        return;
       }
 
       // At this point, any exception indicates an issue with the original request/response.
@@ -284,55 +284,55 @@ self.addEventListener('fetch', function (event) {
 [MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
         request.method,
         request.url,
-        `${error.name}: ${error.message}`,
-      )
-    }),
-  )
-})
+        `${error.name}: ${error.message}`
+      );
+    })
+  );
+});
 
 function serializeHeaders(headers) {
-  const reqHeaders = {}
+  const reqHeaders = {};
   headers.forEach((value, name) => {
     reqHeaders[name] = reqHeaders[name]
       ? [].concat(reqHeaders[name]).concat(value)
-      : value
-  })
-  return reqHeaders
+      : value;
+  });
+  return reqHeaders;
 }
 
 function sendToClient(client, message) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel()
+    const channel = new MessageChannel();
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error)
+        return reject(event.data.error);
       }
 
-      resolve(event.data)
-    }
+      resolve(event.data);
+    };
 
-    client.postMessage(JSON.stringify(message), [channel.port2])
-  })
+    client.postMessage(JSON.stringify(message), [channel.port2]);
+  });
 }
 
 function delayPromise(cb, duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(cb()), duration)
-  })
+    setTimeout(() => resolve(cb()), duration);
+  });
 }
 
 function respondWithMock(clientMessage) {
   return new Response(clientMessage.payload.body, {
     ...clientMessage.payload,
     headers: clientMessage.payload.headers,
-  })
+  });
 }
 
 function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0
-    const v = c == 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c == "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }

--- a/src/api/facets.ts
+++ b/src/api/facets.ts
@@ -1,0 +1,57 @@
+import { mapValues } from "lodash";
+import { Params } from ".";
+import { Options } from "@/components/AppSelectMulti.d";
+import { labelToId } from "./taxons";
+import { renameKey } from "./../util/object";
+
+// format of facet counts returned from biolink
+export type Facets = Record<string, Record<string, number>>;
+
+// set of filters compatible with select options list
+export type Filters = Record<string, Options> | null;
+
+// simplified filter format for passing to api funcs
+export type Query = Record<string, Array<string>>;
+
+// convert backend facets into filters (set of options) compatible with select components
+export const facetsToFilters = (facets: Facets): Filters => {
+  const filters: Filters = {};
+  for (const [name, facet] of Object.entries(facets)) {
+    filters[name] = [];
+    for (const [id, count] of Object.entries(facet)) {
+      filters[name].push({ id, count });
+    }
+  }
+
+  // rename facet names to be consistent, and to be what biolink expects in
+  // future queries
+  renameKey(filters, "taxon_label", "taxon");
+  renameKey(filters, "object_taxon_label", "taxon");
+
+  return filters;
+};
+
+// convert filters to query for passing to api funcs
+export const filtersToQuery = (filters: Filters): Query =>
+  mapValues(filters, (array) => array.map(({ id }) => id)) as Query;
+
+// convert query to params for passing to request func
+export const queryToParams = (
+  availableFilters: Query,
+  activeFilters: Query
+): Params => {
+  const params: Params = {};
+  // eslint-disable-next-line
+  for (let [key, query] of Object.entries(activeFilters)) {
+    // do special mapping for certain keys
+    if (key === "taxon") query = query.map(labelToId);
+
+    // ignore filter if value "empty" (none active) or "full" (all active)
+    const noneActive = query.length === 0;
+    const allActive =
+      activeFilters[key]?.length === availableFilters[key]?.length;
+    if (!noneActive && !allActive) params[key] = query;
+  }
+
+  return params;
+};

--- a/src/api/node-associations.ts
+++ b/src/api/node-associations.ts
@@ -1,6 +1,9 @@
 import { startCase } from "lodash";
 import { biolink, request, cleanError } from ".";
+import { Filters, Query, facetsToFilters, queryToParams } from "./facets";
+import { getSummaries } from "./node-publication";
 import { mapCategory, getAssociationEndpoint } from "./categories";
+import { Sort } from "@/components/AppTable";
 
 interface Response {
   numFound: number;
@@ -46,26 +49,25 @@ interface Response {
         meta: Record<string, unknown>;
       }>;
     };
-    evidence_types: Array<{
+    evidence_types?: Array<{
       id: string;
       label: string;
     }>;
-    provided_by: Array<string>;
-    frequency: {
-      id?: string;
-      label?: string;
-    };
-    onset: {
-      id?: string;
-      label?: string;
-    };
-    publications: Array<{
+    provided_by?: Array<string>;
+    publications?: Array<{
       id: string;
       label: string;
     }>;
+    frequency?: {
+      id?: string;
+      label?: string;
+    };
+    onset?: {
+      id?: string;
+      label?: string;
+    };
   }>;
-
-  facet_counts: Record<string, unknown>;
+  facet_counts: Record<string, Record<string, number>>;
 }
 
 // get associations between a node and a category
@@ -75,7 +77,10 @@ export const getTabulatedAssociations = async (
   assocationCategory = "",
   rows = 10,
   start = 0,
-  search = ""
+  search = "",
+  sort: Sort = null,
+  availableFilters: Query = {},
+  activeFilters: Query = {}
 ): Promise<Result> => {
   try {
     // get causal/correlated param
@@ -88,7 +93,12 @@ export const getTabulatedAssociations = async (
       rows,
       start,
       association_type: type,
-      ...(search ? { q: search } : {}),
+      facet: true,
+      q: search || null,
+      sort: sort
+        ? `${sort.id} ${sort.direction === "up" ? "asc" : "desc"}`
+        : null,
+      ...queryToParams(availableFilters, activeFilters),
     };
 
     // make query
@@ -98,39 +108,102 @@ export const getTabulatedAssociations = async (
     const response = await request<Response>(url, params);
 
     // convert into desired result format
-    const associations = response.associations.map((association) => ({
-      id: association.id,
-      object: {
-        id: association.object.id,
-        name: association.object.label,
-        iri: association.object.iri,
-        category: mapCategory(association.object.category || []),
-        taxon: {
-          id: association.object.taxon?.id || "",
-          name: association.object.taxon?.label || "",
-        },
-      },
-      subject: {
-        id: association.subject.id,
-        name: association.subject.label,
-        iri: association.subject.iri,
-        category: mapCategory(association.subject.category || []),
-        taxon: {
-          id: association.subject.taxon?.id || "",
-          name: association.subject.taxon?.label || "",
-        },
-      },
-      relation: {
-        id: association.relation.id,
-        name: startCase(association.relation.label),
-        iri: association.relation.iri,
-        category: (association.relation?.category || [])[0] || "",
-        inverse: association.relation.inverse,
-      },
-      evidence: [],
-    }));
+    const associations: Result["associations"] = response.associations.map(
+      (association) => ({
+        // see result interface below...
+        id: association.id,
 
-    return { count: response.numFound || 0, associations };
+        // ...
+        object: {
+          id: association.object.id,
+          name: association.object.label,
+          iri: association.object.iri,
+          category: mapCategory(association.object.category || []),
+        },
+
+        // ...
+        subject: {
+          id: association.subject.id,
+          name: association.subject.label,
+          iri: association.subject.iri,
+          category: mapCategory(association.subject.category || []),
+        },
+
+        // ...
+        relation: {
+          id: association.relation.id,
+          name: startCase(association.relation.label),
+          iri: association.relation.iri,
+          category: (association.relation?.category || [])[0] || "",
+          inverse: association.relation.inverse,
+        },
+
+        // ...
+        evidence: [],
+
+        // ...
+        taxon:
+          association.object.taxon?.id || association.object.taxon?.label
+            ? {
+                id: association.object.taxon?.id || "",
+                name: association.object.taxon?.label || "",
+              }
+            : undefined,
+
+        // ...
+        frequency:
+          association.frequency?.id || association.frequency?.label
+            ? {
+                id: association.frequency?.id || "",
+                name: association.frequency?.label || "",
+              }
+            : undefined,
+        onset:
+          association.onset?.id || association.onset?.label
+            ? {
+                id: association.onset?.id || "",
+                name: association.onset?.label || "",
+              }
+            : undefined,
+
+        // ...
+        supportCount:
+          (association.evidence_types || []).length +
+          (association.publications || []).filter((publication) =>
+            publication.id.startsWith("PMID:")
+          ).length +
+          (association.provided_by || []).length,
+      })
+    );
+
+    // supplement publication with metadata from entrez
+    {
+      // get list of publication ids
+      const ids = associations
+        .filter((association) => association.object.category === "publication")
+        .map((association) => association.object.id);
+
+      // get summaries for all ids at same time
+      const summaries = await getSummaries(ids);
+
+      for (const [id, publication] of Object.entries(summaries)) {
+        // find original association
+        const association = associations.find(
+          (association) => association.object.id === id
+        );
+        if (!association) continue;
+
+        // incorporate response data back into associations
+        association.author = publication.authors[0] || "";
+        association.year = String(publication.date?.getFullYear() || "");
+        association.publisher = publication.journal;
+      }
+    }
+
+    // get facets for filters
+    const facets = facetsToFilters(response.facet_counts);
+
+    return { count: response.numFound || 0, associations, facets };
   } catch (error) {
     throw cleanError(error);
   }
@@ -139,27 +212,29 @@ export const getTabulatedAssociations = async (
 export interface Result {
   count: number;
   associations: Array<{
+    // allow arbitrary key access
+    [key: string]: unknown;
+
+    // unique id of association
     id: string;
+
+    // subject of association, i.e. current node
     subject: {
       id: string;
       name: string;
       iri: string;
       category: string;
-      taxon: {
-        id: string;
-        name: string;
-      };
     };
+
+    // object of association, i.e. what current node has association with
     object: {
       id: string;
       name: string;
       iri: string;
       category: string;
-      taxon: {
-        id: string;
-        name: string;
-      };
     };
+
+    // info about the association
     relation: {
       id: string;
       name: string;
@@ -167,8 +242,36 @@ export interface Result {
       category: string;
       inverse: boolean;
     };
+
+    // evidence info supporting this association
     evidence: Array<Record<string, unknown>>;
+
+    // mixed-type total of pieces of supporting evidence
+    supportCount: number;
+
+    // taxon specific (gene/genotype/model/variant/homolog/ortholog) info
+    taxon?: {
+      id: string;
+      name: string;
+    };
+
+    // phenotype specific info
+    frequency?: {
+      id: string;
+      name: string;
+    };
+    onset?: {
+      id: string;
+      name: string;
+    };
+
+    // publication specific info
+    author?: string;
+    year?: string;
+    publisher?: string;
   }>;
+
+  facets: Filters;
 }
 
 // get top few associations

--- a/src/api/node-hierachy.ts
+++ b/src/api/node-hierachy.ts
@@ -36,7 +36,7 @@ export const getHierarchy = async (id = "", category = ""): Promise<Result> => {
         "function",
       ].includes(category)
         ? // only do subclass and "part of"for certain node types
-          `equivalentClass,subClassOf,${partOf}`
+          ["equivalentClass", "subClassOf", partOf]
         : // otherwise just look for equivalent classes
           "equivalentClass",
     };

--- a/src/api/phenogrid.ts
+++ b/src/api/phenogrid.ts
@@ -40,7 +40,6 @@ export const mountPhenogrid = async (
 
     patchSvg(await waitFor("#phenogrid_svg"));
   } catch (error) {
-    console.error(error);
     throw cleanError(error);
   }
 };

--- a/src/api/phenotype-explorer.ts
+++ b/src/api/phenotype-explorer.ts
@@ -138,7 +138,7 @@ export const compareSetToTaxon = async (
 ): Promise<CompareResult> => {
   // endpoint settings
   const params = {
-    id: phenotypes.join(","),
+    id: phenotypes,
     taxon: getTaxonIdFromName(taxon),
   };
 

--- a/src/components/AppCitation.vue
+++ b/src/components/AppCitation.vue
@@ -30,9 +30,9 @@ interface Props {
 const props = defineProps<Props>();
 
 // joined details as string
-const detailsString = computed(() => {
-  return (props.details || []).filter((e) => e).join("&nbsp; · &nbsp;");
-});
+const detailsString = computed(() =>
+  (props.details || []).filter((e) => e).join("&nbsp; · &nbsp;")
+);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -20,7 +20,11 @@
     <slot v-else />
   </a>
 
-  <router-link v-else :to="to" :replace="to.startsWith('#')">
+  <router-link
+    v-else
+    :to="to.startsWith('#') ? { ...$route, hash: to } : to"
+    :replace="to.startsWith('#')"
+  >
     <!-- use vue router component for relative urls -->
     <slot />
   </router-link>

--- a/src/components/AppSelectMulti.vue
+++ b/src/components/AppSelectMulti.vue
@@ -146,7 +146,7 @@ interface Emits {
   // when value changed
   (event: "input"): void;
   // when value change "submitted"/"committed" by user
-  (event: "change"): void;
+  (event: "change", value: Options): void;
 }
 
 const emit = defineEmits<Emits>();
@@ -159,23 +159,19 @@ const expanded = ref(false);
 const selected = ref<Array<number>>([]);
 // index of option that is highlighted
 const highlighted = ref(0);
-// model value when opened
-const original = ref<Options>([]);
 
 function open() {
   // open dropdown
   expanded.value = true;
   // auto highlight first selected option
   highlighted.value = selected.value[0] || 0;
-  // remember model value when opened
-  original.value = props.modelValue;
 }
 
 function close() {
   // close dropdown
   expanded.value = false;
   // emit event that user has "committed" change
-  if (!isEqual(props.modelValue, original.value)) emit("change");
+  emit("change", getModel());
 }
 
 // when button clicked
@@ -275,7 +271,7 @@ watch(
   { deep: true, immediate: true }
 );
 
-// when selected index changes
+// when selected index changes, update model
 watch(selected, () => emit("update:modelValue", getModel()), { deep: true });
 
 // when highlighted index changes
@@ -326,7 +322,7 @@ const allSelected = computed(
   position: absolute;
   min-width: 100%;
   max-width: 90vw;
-  max-height: 200px;
+  max-height: 300px;
   overflow-x: auto;
   overflow-y: auto;
   background: $white;

--- a/src/components/AppSelectMulti.vue
+++ b/src/components/AppSelectMulti.vue
@@ -114,7 +114,9 @@
             />
           </span>
           <span class="option-label">{{ startCase(option.id) }}</span>
-          <span class="option-count">{{ option.count }}</span>
+          <span class="option-count">
+            {{ showCounts ? option.count : "" }}
+          </span>
         </div>
       </div>
     </div>
@@ -136,6 +138,8 @@ interface Props {
   options: Options;
   // width style of button
   width?: string;
+  // whether to show count col
+  showCounts?: boolean;
 }
 
 const props = defineProps<Props>();
@@ -245,16 +249,21 @@ function toggleSelect(index = -1, shift = false) {
         .fill(0)
         .map((_, index) => index);
   }
+  // solo/un-solo one
+  else if (shift) {
+    if (isEqual(selected.value, [index]))
+      selected.value = Array(props.options.length)
+        .fill(0)
+        .map((_, index) => index);
+    else selected.value = [index];
+  }
   // toggle one
   else {
-    if (shift) {
-      selected.value = [index];
-    } else {
-      if (selected.value.includes(index))
-        selected.value = selected.value.filter((value) => value !== index);
-      else selected.value.push(index);
-    }
+    if (selected.value.includes(index))
+      selected.value = selected.value.filter((value) => value !== index);
+    else selected.value.push(index);
   }
+
   // keep in order for easy comparison
   selected.value.sort();
   // emit input event for listening for only user-originated inputs

--- a/src/components/AppSelectSingle.vue
+++ b/src/components/AppSelectSingle.vue
@@ -238,7 +238,7 @@ watch(
   transform: translateX(-50%);
   min-width: 100%;
   max-width: 90vw;
-  max-height: 200px;
+  max-height: 300px;
   overflow-x: hidden;
   overflow-y: auto;
   background: $white;

--- a/src/components/AppSelectTags.vue
+++ b/src/components/AppSelectTags.vue
@@ -413,7 +413,7 @@ input {
 
 .list {
   position: absolute;
-  max-height: 200px;
+  max-height: 300px;
   width: 100%;
   overflow-x: auto;
   overflow-y: auto;

--- a/src/components/AppTable.d.ts
+++ b/src/components/AppTable.d.ts
@@ -1,8 +1,7 @@
-import { Options } from "./AppSelectMulti";
-
 // table column
 export interface Col {
-  // unique id, used to identify sorting and match with named slots
+  // unique id, used to identify/match for sorting, filtering, and named slots
+  // use "divider" to create vertical divider to separate cols
   id: string;
   // what item in row object to access as raw cell value
   key?: string;
@@ -14,10 +13,6 @@ export interface Col {
   width?: string;
   // whether to allow sorting of column
   sortable?: boolean;
-  // available filters for column
-  availableFilters?: Options;
-  // active filters for column
-  activeFilters?: Options;
 }
 
 // object with arbitrary keys
@@ -27,8 +22,8 @@ export type Row = Record<string, unknown>;
 export type Cols = Array<Col>;
 export type Rows = Array<Row>;
 
-// sort param
-interface Sort {
-  id?: string;
-  direction?: "up" | "down";
-}
+// sort prop
+export type Sort = {
+  id: string;
+  direction: "up" | "down";
+} | null;

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -7,150 +7,162 @@
 -->
 
 <template>
-  <AppFlex direction="col">
-    <div class="table" :data-disabled="disabled">
-      <table
-        :aria-colcount="cols.length"
-        :aria-rowcount="rows.length"
-        :style="{ gridTemplateColumns: widths }"
-      >
-        <!-- head -->
-        <thead>
-          <tr>
-            <th
-              v-for="(col, colIndex) in cols"
-              :key="colIndex"
-              :aria-sort="ariaSort"
-              :data-align="col.align || 'left'"
-            >
-              <span>
-                {{ col.heading }}
-              </span>
-              <AppButton
-                v-if="col.sortable"
-                v-tippy="'Sort by ' + col.heading"
-                :icon="
-                  'arrow-' + (sort?.id === col.id ? sort?.direction : 'down')
-                "
-                design="small"
-                :color="sort?.id === col.id ? 'primary' : 'secondary'"
-                @click.stop="emitSort(col)"
-              />
-              <AppSelectMulti
-                v-if="
-                  col.availableFilters &&
-                  col.activeFilters &&
-                  col.availableFilters?.length
-                "
-                v-slot="slotProps"
-                :name="'Filter by ' + col.heading"
-                :options="col.availableFilters"
-                :model-value="col.activeFilters"
-                @update:model-value="(value) => emitFilter(colIndex, value)"
+  <div class="container">
+    <!-- status -->
+    <AppStatus v-if="status" :status="status" />
+
+    <!-- table data -->
+    <AppFlex direction="col" :data-disabled="!!status">
+      <div class="table">
+        <table
+          :aria-colcount="cols.length"
+          :aria-rowcount="rows.length"
+          :style="{ gridTemplateColumns: widths }"
+        >
+          <!-- head -->
+          <thead>
+            <tr>
+              <th
+                v-for="(col, colIndex) in cols"
+                :key="colIndex"
+                :aria-sort="ariaSort"
+                :data-align="col.align || 'left'"
+                :data-divider="col.id === 'divider'"
               >
+                <span>
+                  {{ col.heading }}
+                </span>
                 <AppButton
-                  v-tippy="'Filter by ' + col.heading"
-                  icon="filter"
+                  v-if="col.sortable"
+                  v-tippy="'Sort by ' + col.heading"
+                  :icon="
+                    'arrow-' + (sort?.id === col.id ? sort?.direction : 'down')
+                  "
                   design="small"
-                  v-bind="kebabify(slotProps)"
+                  :color="sort?.id === col.id ? 'primary' : 'secondary'"
+                  :style="{ opacity: sort?.id === col.id ? 1 : 0.35 }"
+                  @click.stop="emitSort(col)"
                 />
-              </AppSelectMulti>
-            </th>
-          </tr>
-        </thead>
+                <AppSelectMulti
+                  v-if="
+                    availableFilters &&
+                    activeFilters &&
+                    availableFilters[col.id] &&
+                    activeFilters[col.id] &&
+                    availableFilters[col.id]?.length
+                  "
+                  v-slot="slotProps"
+                  :name="'Filter by ' + col.heading"
+                  :options="availableFilters[col.id]"
+                  :model-value="activeFilters[col.id]"
+                  @change="(value) => emitFilter(col.id, value)"
+                >
+                  <AppButton
+                    v-tippy="'Filter by ' + col.heading"
+                    icon="filter"
+                    design="small"
+                    v-bind="kebabify(slotProps)"
+                  />
+                </AppSelectMulti>
+              </th>
+            </tr>
+          </thead>
 
-        <!-- body -->
-        <tbody>
-          <tr v-for="(row, rowIndex) in rows" :key="rowIndex">
-            <td
-              v-for="(col, colIndex) in cols"
-              :key="colIndex"
-              :aria-rowindex="rowIndex + 1"
-              :aria-colindex="colIndex + 1"
-              :data-align="col.align || 'left'"
-            >
-              <!-- if slot w/ name == col id, use to custom format/template cell -->
-              <slot
-                v-if="$slots[col.id]"
-                :name="col.id"
-                :row="row"
-                :col="col"
-                :cell="col.key ? row[col.key] : {}"
-              />
-              <!-- otherwise, just display raw cell value -->
-              <template v-else-if="col.key">
-                {{ row[col.key] }}
-              </template>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+          <!-- body -->
+          <tbody>
+            <tr v-for="(row, rowIndex) in rows" :key="rowIndex">
+              <td
+                v-for="(col, colIndex) in cols"
+                :key="colIndex"
+                :aria-rowindex="rowIndex + 1"
+                :aria-colindex="colIndex + 1"
+                :data-align="col.align || 'left'"
+                :data-divider="col.id === 'divider'"
+              >
+                <!-- if slot w/ name == col id, use to custom format/template cell -->
+                <slot
+                  v-if="$slots[col.id]"
+                  :name="col.id"
+                  :row="row"
+                  :col="col"
+                  :cell="col.key ? row[col.key] : {}"
+                />
+                <!-- otherwise, just display raw cell value -->
+                <template v-else-if="col.key">
+                  {{ row[col.key] }}
+                </template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-    <div class="controls" :data-disabled="disabled">
-      <div>
-        <span>Per page</span>
-        <AppSelectSingle
-          name="Rows per page"
-          :options="[
-            { id: '5' },
-            { id: '10' },
-            { id: '20' },
-            { id: '50' },
-            { id: '100' },
-          ]"
-          :model-value="{ id: String(perPage || 5) }"
-          @update:model-value="(value) => emitPerPage(value.id)"
-        />
+      <div class="controls">
+        <div>
+          <span>Per page</span>
+          <AppSelectSingle
+            name="Rows per page"
+            :options="[
+              { id: '5' },
+              { id: '10' },
+              { id: '20' },
+              { id: '50' },
+              { id: '100' },
+              { id: '500' },
+            ]"
+            :model-value="{ id: String(perPage || 5) }"
+            @update:model-value="(value) => emitPerPage(value.id)"
+          />
+        </div>
+        <div>
+          <AppButton
+            v-tippy="'Go to first page'"
+            :disabled="start <= 0"
+            icon="angle-double-left"
+            design="small"
+            @click="clickFirst"
+          />
+          <AppButton
+            v-tippy="'Go to previous page'"
+            :disabled="start - perPage < 0"
+            icon="angle-left"
+            design="small"
+            @click="clickPrev"
+          />
+          <span>{{ start + 1 }} &mdash; {{ end }} of {{ total }}</span>
+          <AppButton
+            v-tippy="'Go to next page'"
+            :disabled="start + perPage > total"
+            icon="angle-right"
+            design="small"
+            @click="clickNext"
+          />
+          <AppButton
+            v-tippy="'Go to last page'"
+            :disabled="start + perPage > total"
+            icon="angle-double-right"
+            design="small"
+            @click="clickLast"
+          />
+        </div>
+        <div>
+          <AppInput
+            v-tippy="'Search table data'"
+            class="search"
+            icon="search"
+            :model-value="search"
+            @change="emitSearch"
+          />
+          <AppButton
+            v-tippy="'Download table data'"
+            icon="download"
+            design="small"
+            @click="emitDownload"
+          />
+        </div>
       </div>
-      <div>
-        <AppButton
-          v-tippy="'Go to first page'"
-          :disabled="start <= 0"
-          icon="angle-double-left"
-          design="small"
-          @click="clickFirst"
-        />
-        <AppButton
-          v-tippy="'Go to previous page'"
-          :disabled="start - perPage < 0"
-          icon="angle-left"
-          design="small"
-          @click="clickPrev"
-        />
-        <span>{{ start + 1 }} &mdash; {{ end }} of {{ total }}</span>
-        <AppButton
-          v-tippy="'Go to next page'"
-          :disabled="start + perPage > total"
-          icon="angle-right"
-          design="small"
-          @click="clickNext"
-        />
-        <AppButton
-          v-tippy="'Go to last page'"
-          :disabled="start + perPage > total"
-          icon="angle-double-right"
-          design="small"
-          @click="clickLast"
-        />
-      </div>
-      <div>
-        <AppInput
-          v-tippy="'Search table data'"
-          class="search"
-          icon="search"
-          :model-value="search"
-          @change="emitSearch"
-        />
-        <AppButton
-          v-tippy="'Download table data'"
-          icon="download"
-          design="small"
-          @click="emitDownload"
-        />
-      </div>
-    </div>
-  </AppFlex>
+    </AppFlex>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -159,8 +171,11 @@ import { Col, Cols, Rows, Sort } from "./AppTable";
 import AppInput from "./AppInput.vue";
 import AppSelectMulti from "./AppSelectMulti.vue";
 import AppSelectSingle from "./AppSelectSingle.vue";
+import AppStatus from "./AppStatus.vue";
 import { Options } from "./AppSelectMulti";
 import { kebabify } from "@/util/object";
+import { Filters } from "@/api/facets";
+import { Status } from "./AppStatus";
 
 interface Props {
   // info for each column of table
@@ -168,7 +183,7 @@ interface Props {
   // list of table rows, i.e. the table data
   rows: Rows;
   // sort key and direction
-  sort?: Sort | null;
+  sort?: Sort;
   // items per page
   perPage: number;
   // starting item index
@@ -177,21 +192,26 @@ interface Props {
   total: number;
   // text being searched
   search?: string;
-  // whether table is disabled (e.g. loading)
-  disabled?: boolean;
+  // filters
+  availableFilters?: Filters;
+  activeFilters?: Filters;
+  // status to show on top of table (e.g. loading)
+  status?: Status | null;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  sort: null,
+  sort: undefined,
   search: "",
-  disabled: false,
+  availableFilters: undefined,
+  activeFilters: undefined,
+  status: null,
 });
 
 interface Emits {
   // when sort changes
   (event: "sort", sort: Sort): void;
   // when filter changes
-  (event: "filter", colIndex: number, value: Options): void;
+  (event: "filter", colId: Col["id"], value: Options): void;
   // when per page changes
   (event: "perPage", value: number): void;
   // when start row changes
@@ -233,7 +253,7 @@ function emitSort(col: Col) {
     if (props.sort?.direction === "down")
       newSort = { id: col.id, direction: "up" };
     else if (props.sort?.direction === "up") {
-      newSort = {};
+      newSort = null;
     } else {
       newSort = { id: col.id, direction: "down" };
     }
@@ -245,8 +265,8 @@ function emitSort(col: Col) {
 }
 
 // when user changes a filter
-function emitFilter(colIndex: number, value: Options) {
-  emit("filter", colIndex, value);
+function emitFilter(colId: Col["id"], value: Options) {
+  emit("filter", colId, value);
 }
 
 // when user changes rows per page
@@ -283,6 +303,19 @@ const ariaSort = computed(() => {
 </script>
 
 <style lang="scss" scoped>
+.container {
+  position: relative;
+  width: 100%;
+
+  .status {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
 .table {
   width: 100%;
   overflow-x: auto;
@@ -307,6 +340,7 @@ td {
   align-items: center;
   gap: 10px;
   padding: 5px 10px;
+  max-width: 300px;
 
   &[data-align="left"] {
     justify-content: flex-start;
@@ -326,11 +360,18 @@ td {
       order: -1;
     }
   }
+
+  &[data-divider="true"] {
+    padding: 0;
+    width: 2px;
+    margin: 0 5px;
+    background: $light-gray;
+  }
 }
 
 // heading cells
 th {
-  margin-bottom: 10px;
+  padding-bottom: 10px;
   font-weight: 400;
 }
 

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -332,14 +332,23 @@ const ariaSort = computed(() => {
   transition: mask-image $fast;
 
   &[data-left="false"] {
+    --webkit-mask-image: linear-gradient(to left, black 90%, transparent);
     mask-image: linear-gradient(to left, black 90%, transparent);
   }
 
   &[data-right="false"] {
+    --webkit-mask-image: linear-gradient(to right, black 90%, transparent);
     mask-image: linear-gradient(to right, black 90%, transparent);
   }
 
   &[data-left="false"][data-right="false"] {
+    --webkit-mask-image: linear-gradient(
+      to left,
+      transparent,
+      black 10%,
+      black 90%,
+      transparent
+    );
     mask-image: linear-gradient(
       to left,
       transparent,

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -13,7 +13,12 @@
 
     <!-- table data -->
     <AppFlex direction="col" :data-disabled="!!status">
-      <div class="table">
+      <div
+        ref="table"
+        class="table"
+        :data-left="arrivedState.left"
+        :data-right="arrivedState.right"
+      >
         <table
           :aria-colcount="cols.length"
           :aria-rowcount="rows.length"
@@ -166,7 +171,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ref, computed } from "vue";
+import { useScroll } from "@vueuse/core";
 import { Col, Cols, Rows, Sort } from "./AppTable";
 import AppInput from "./AppInput.vue";
 import AppSelectMulti from "./AppSelectMulti.vue";
@@ -223,6 +229,10 @@ interface Emits {
 }
 
 const emit = defineEmits<Emits>();
+
+// table reference
+const table = ref<HTMLElement | null>(null);
+const { arrivedState } = useScroll(table);
 
 // when user clicks to first page
 function clickFirst() {
@@ -319,6 +329,25 @@ const ariaSort = computed(() => {
 .table {
   width: 100%;
   overflow-x: auto;
+  transition: mask-image $fast;
+
+  &[data-left="false"] {
+    mask-image: linear-gradient(to left, black 90%, transparent);
+  }
+
+  &[data-right="false"] {
+    mask-image: linear-gradient(to right, black 90%, transparent);
+  }
+
+  &[data-left="false"][data-right="false"] {
+    mask-image: linear-gradient(
+      to left,
+      transparent,
+      black 10%,
+      black 90%,
+      transparent
+    );
+  }
 }
 
 table {

--- a/src/components/TheFeedbackForm.vue
+++ b/src/components/TheFeedbackForm.vue
@@ -83,10 +83,11 @@ import { useLocalStorage } from "@vueuse/core";
 import parser from "ua-parser-js";
 import AppInput from "@/components/AppInput.vue";
 import { Status } from "@/components/AppStatus";
-import { truncate, collapse } from "@/util/string";
+import { collapse } from "@/util/string";
 import { postFeedback } from "@/api/feedback";
 import AppStatus from "./AppStatus.vue";
 import { ApiError } from "@/api";
+import { truncate } from "lodash";
 
 // route info
 const route = useRoute();
@@ -138,8 +139,8 @@ async function onSubmit() {
   // make issue title (unclear what char limit is?)
   const title = [
     "Feedback form",
-    truncate(name.value, 20),
-    truncate(collapse(feedback.value), 60),
+    truncate(name.value, { length: 20 }),
+    truncate(collapse(feedback.value), { length: 60 }),
   ].join(" - ");
 
   // make issue body markdown

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -38,3 +38,15 @@ export const kebabify = (
   mapKeys(object, (value, key: string) =>
     key.includes("on") ? key : kebabCase(key)
   );
+
+// rename key in object in place
+export const renameKey = (
+  object: Record<string, unknown>,
+  oldKey: string,
+  newKey: string
+): void => {
+  if (object[oldKey]) {
+    object[newKey] = object[oldKey];
+    delete object[oldKey];
+  }
+};

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,7 +1,3 @@
-// truncate string above certain length
-export const truncate = (value = "", limit = 20): string =>
-  value.length > limit ? value.slice(0, limit - 3) + "..." : value;
-
 // collapse whitespace in string
 export const collapse = (value = ""): string =>
   value.replace(/\s+/g, " ").trim();

--- a/src/views/PageTestbed.vue
+++ b/src/views/PageTestbed.vue
@@ -42,12 +42,12 @@
   <AppSection>
     <AppHeading>Table</AppHeading>
     <span>{{ omit(table, ["cols", "rows"]) }}</span>
-    <span>{{ table.cols.map(({ activeFilters }) => activeFilters) }}</span>
     <AppTable
       v-bind="table"
+      @start="(value) => (table.start = value)"
       @sort="(value) => (table.sort = value)"
       @filter="
-        (colIndex, value) => (table.cols[colIndex].activeFilters = value)
+        (colId, value) => ((table.activeFilters || {})[colId] = [...value])
       "
       @per-page="(value) => (table.perPage = value)"
       @search="(value) => (table.search = value)"
@@ -178,6 +178,7 @@ import AppTable from "@/components/AppTable.vue";
 import AppTabs from "@/components/AppTabs.vue";
 import { Cols, Rows, Sort } from "@/components/AppTable";
 import { sleep } from "@/util/debug";
+import { Filters } from "@/api/facets";
 
 type ButtonProps = InstanceType<typeof AppButton>["$props"];
 
@@ -211,8 +212,7 @@ const table = ref({
       id: "score",
       key: "score",
       heading: "Score",
-      availableFilters: [{ id: "numbers" }, { id: "nulls" }],
-      activeFilters: [{ id: "numbers" }],
+
       sortable: true,
     },
     {
@@ -238,10 +238,12 @@ const table = ref({
   ] as Rows,
   sort: { id: "score", direction: "up" } as Sort,
   perPage: 10,
-  start: 1,
+  start: 0,
   end: 11,
   total: 123,
   search: "",
+  availableFilters: { score: [{ id: "numbers" }, { id: "nulls" }] } as Filters,
+  activeFilters: { score: [{ id: "numbers" }] } as Filters,
 });
 
 // single select
@@ -285,5 +287,5 @@ const tagsSelectValue = ref([
 ]);
 
 // util
-const log = console.log;
+const log = console.info;
 </script>

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -121,11 +121,12 @@ import { kebabCase, startCase, uniq } from "lodash";
 import AppInput from "@/components/AppInput.vue";
 import AppStatus from "@/components/AppStatus.vue";
 import { ApiError } from "@/api";
-import { getSearchResults, mapFilters, Result } from "@/api/node-search";
+import { getSearchResults, Result } from "@/api/node-search";
 import { Status } from "@/components/AppStatus";
 import AppSelectMulti from "@/components/AppSelectMulti.vue";
 import { Options } from "@/components/AppSelectMulti";
 import { useRoute, useRouter } from "vue-router";
+import { filtersToQuery } from "@/api/facets";
 
 // route info
 const router = useRouter();
@@ -213,8 +214,8 @@ async function getResults(
     // get results from api
     const response = await getSearchResults(
       search.value,
-      fresh ? undefined : mapFilters(availableFilters.value),
-      fresh ? undefined : mapFilters(activeFilters.value),
+      fresh ? undefined : filtersToQuery(availableFilters.value),
+      fresh ? undefined : filtersToQuery(activeFilters.value),
       fresh ? undefined : from.value
     );
     results.value = response.results;

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -39,6 +39,7 @@
           v-tippy="`${startCase(name)} filter`"
           :name="`${name}`"
           :options="availableFilters[name]"
+          :show-counts="showCounts"
           @change="onFilterChange"
         />
       </template>
@@ -117,7 +118,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
-import { kebabCase, startCase, uniq } from "lodash";
+import { isEqual, kebabCase, startCase, uniq } from "lodash";
 import AppInput from "@/components/AppInput.vue";
 import AppStatus from "@/components/AppStatus.vue";
 import { ApiError } from "@/api";
@@ -163,6 +164,8 @@ const status = ref<Status | null>(null);
 // filters (facets) for search
 const availableFilters = ref<Record<string, Options>>({});
 const activeFilters = ref<Record<string, Options>>({});
+// whether to show counts in filter dropdowns
+const showCounts = ref(true);
 
 // when user focuses text box
 async function onFocus() {
@@ -205,6 +208,9 @@ async function getResults(
     if (search.value) query.search = search.value;
     await router.push({ ...route, name: "Explore", query });
   }
+
+  // hide counts in filter dropdowns if any filtering being done
+  showCounts.value = isEqual(activeFilters.value, availableFilters.value);
 
   // loading...
   status.value = { code: "loading", text: "Loading results" };

--- a/src/views/node/AssociationsSummary.vue
+++ b/src/views/node/AssociationsSummary.vue
@@ -18,8 +18,8 @@
     >
       <AppFlex direction="col" gap="small" class="details">
         <!-- primary result info -->
-        <AppFlex gap="small" h-align="left" class="title">
-          <span>{{ node.name }}</span>
+        <AppFlex gap="small" h-align="left" :wrap="false" class="title">
+          <span class="truncate">{{ node.name }}</span>
           <AppIcon
             class="arrow"
             :icon="
@@ -47,9 +47,10 @@
 
         <!-- secondary result info -->
         <AppFlex h-align="left" class="secondary">
-          <span>XX supporting evidence</span>
-          <span>XX frequency</span>
-          <span>XX publications</span>
+          <span
+            >{{ association.supportCount }} piece(s) of supporting
+            evidence</span
+          >
         </AppFlex>
       </AppFlex>
 
@@ -69,7 +70,6 @@ import { ref, watch, onMounted } from "vue";
 import AppStatus from "@/components/AppStatus.vue";
 import { Status } from "@/components/AppStatus";
 import { Result as NodeResult } from "@/api/node-lookup";
-import { Option } from "@/components/AppSelectSingle";
 import {
   getTopAssociations,
   Result as AssociationsResult,
@@ -80,7 +80,7 @@ interface Props {
   // current node
   node: NodeResult;
   // selected association category
-  category: Option;
+  category: string;
 }
 
 const props = defineProps<Props>();
@@ -105,7 +105,7 @@ async function getAssociations() {
     associations.value = await getTopAssociations(
       props.node.id,
       props.node.category,
-      props.category.id
+      props.category
     );
 
     // clear status
@@ -137,6 +137,7 @@ onMounted(getAssociations);
 }
 
 .details {
+  width: 0;
   flex-grow: 1;
 }
 

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -210,18 +210,20 @@ const cols = computed((): Cols => {
         id: "author",
         key: "author",
         heading: "Author",
+        width: "max-content",
       },
       {
         id: "year",
         key: "year",
         heading: "Year",
-        width: "max-content",
         align: "center",
+        width: "max-content",
       },
       {
         id: "publisher",
         key: "publisher",
         heading: "Publisher",
+        width: "max-content",
       }
     );
 

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -3,72 +3,107 @@
 -->
 
 <template>
-  <div class="container">
-    <!-- status -->
-    <AppStatus v-if="status" :status="status" />
-
-    <!-- results -->
-    <AppTable
-      :cols="cols"
-      :rows="associations"
-      :per-page="perPage"
-      :start="start"
-      :total="count"
-      :search="search"
-      :disabled="!!status"
-      @per-page="(value) => (perPage = value)"
-      @start="(value) => (start = value)"
-      @search="(value) => (search = value)"
-      @download="download"
-    >
-      <!-- "object" (current node) -->
-      <template #subject="{ cell }">
+  <!-- results -->
+  <AppTable
+    :cols="cols"
+    :rows="associations"
+    :per-page="perPage"
+    :start="start"
+    :total="count"
+    :search="search"
+    :sort="sort"
+    :available-filters="availableFilters"
+    :active-filters="activeFilters"
+    :status="status"
+    @per-page="(value) => (perPage = value)"
+    @start="(value) => (start = value)"
+    @search="(value) => (search = value)"
+    @download="download"
+    @sort="(value) => (sort = value)"
+    @filter="onFilterChange"
+  >
+    <!-- "object" (current node) -->
+    <template #subject="{ cell }">
+      <span class="truncate">
         {{ cell.name }}
-      </template>
+      </span>
+    </template>
 
-      <!-- type of association/relation -->
-      <template #relation="{ cell }">
-        <AppIcon
-          class="arrow"
-          :icon="cell.inverse ? 'arrow-left-long' : 'arrow-right-long'"
-        />
-        <AppLink class="truncate" :to="cell.iri" :no-icon="true">{{
-          cell.name
-        }}</AppLink>
-        <AppIcon
-          class="arrow"
-          :icon="cell.inverse ? 'arrow-left-long' : 'arrow-right-long'"
-        />
-      </template>
+    <!-- type of association/relation -->
+    <template #relation="{ cell }">
+      <AppIcon
+        class="arrow"
+        :icon="cell.inverse ? 'arrow-left-long' : 'arrow-right-long'"
+      />
+      <AppLink class="truncate" :to="cell.iri" :no-icon="true">{{
+        cell.name
+      }}</AppLink>
+      <AppIcon
+        class="arrow"
+        :icon="cell.inverse ? 'arrow-left-long' : 'arrow-right-long'"
+      />
+    </template>
 
-      <!-- "subject" (what current node has an association with) -->
-      <template #object="{ cell }">
-        <AppLink class="truncate" :to="`/${cell.category}/${cell.id}`">{{
-          cell.name
-        }}</AppLink>
-      </template>
+    <!-- "subject" (what current node has an association with) -->
+    <template #object="{ cell }">
+      <AppLink class="truncate" :to="`/${cell.category}/${cell.id}`">{{
+        cell.name
+      }}</AppLink>
+    </template>
 
-      <!-- button to show evidence -->
-      <template #evidence>
-        <AppButton
-          v-tippy="'View supporting evidence for this association'"
-          class="evidence-button"
-          icon="eye"
-          color="secondary"
-        />
-      </template>
-    </AppTable>
-  </div>
+    <!-- button to show evidence -->
+    <template #evidence="{ cell }">
+      <AppButton
+        v-tippy="
+          `View ${cell} piece(s) of supporting evidence for this association`
+        "
+        class="evidence-button"
+        icon="eye"
+        :text="String(cell)"
+        color="secondary"
+      />
+    </template>
+
+    <!-- extra columns -->
+
+    <!-- taxon specific -->
+    <template #taxon="{ cell }">
+      <span class="truncate">
+        {{ cell?.name }}
+      </span>
+    </template>
+
+    <!-- publication specific -->
+    <template #frequency="{ cell }">
+      <AppLink
+        v-if="cell"
+        class="truncate"
+        :to="`http://purl.obolibrary.org/obo/${cell?.id?.replace(':', '_')}`"
+        :no-icon="true"
+      >
+        {{ cell?.name }}
+      </AppLink>
+    </template>
+
+    <template #onset="{ cell }">
+      <AppLink
+        v-if="cell"
+        class="truncate"
+        :to="`http://purl.obolibrary.org/obo/${cell?.id?.replace(':', '_')}`"
+        :no-icon="true"
+      >
+        {{ cell?.name }}
+      </AppLink>
+    </template>
+  </AppTable>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
 import { startCase } from "lodash";
-import { Option } from "@/components/AppSelectSingle";
-import AppStatus from "@/components/AppStatus.vue";
 import { Status } from "@/components/AppStatus";
 import AppTable from "@/components/AppTable.vue";
-import { Cols } from "@/components/AppTable";
+import { Col, Cols, Sort } from "@/components/AppTable";
 import { Result as NodeResult } from "@/api/node-lookup";
 import {
   getTabulatedAssociations,
@@ -77,12 +112,14 @@ import {
 import { ApiError } from "@/api";
 import { downloadJson } from "@/util/download";
 import { push } from "@/components/TheSnackbar";
+import { Filters, filtersToQuery } from "@/api/facets";
+import { Options } from "@/components/AppSelectMulti";
 
 interface Props {
   // current node
   node: NodeResult;
   // selected association category
-  category: Option;
+  category: string;
 }
 
 const props = defineProps<Props>();
@@ -92,44 +129,127 @@ const associations = ref<AssociationsResult["associations"]>([]);
 // total number of associations
 const count = ref(0);
 // table state
+const sort = ref<Sort>();
 const perPage = ref(5);
 const start = ref(0);
 const search = ref("");
+const availableFilters = ref<Filters>({});
+const activeFilters = ref<Filters>({});
 // status of query
 const status = ref<Status | null>(null);
 
 // table columns
-const cols = computed(
-  (): Cols => [
+const cols = computed((): Cols => {
+  // standard columns, always present
+  const baseCols: Cols = [
     {
       id: "subject",
       key: "subject",
       heading: startCase(props.node.category),
+      width: "1fr",
+      sortable: true,
     },
     {
       id: "relation",
       key: "relation",
       heading: "Association",
-      width: "min-content",
+      width: "1fr",
+      sortable: true,
     },
     {
       id: "object",
       key: "object",
-      heading: startCase(props.category.id),
-      width: "minmax(150px, 1fr)",
+      heading: startCase(props.category),
+      width: "1fr",
+      sortable: true,
     },
     {
       id: "evidence",
-      key: "evidence",
+      key: "supportCount",
       heading: "Evidence",
       width: "min-content",
       align: "center",
     },
-  ]
-);
+  ];
+
+  // extra, supplemental columns for certain association types
+  let extraCols: Cols = [];
+
+  // taxon column
+  // exists for many categories, so just add if any row has taxon
+  if (associations.value.some((association) => association.taxon))
+    extraCols.push({
+      id: "taxon",
+      key: "taxon",
+      heading: "Taxon",
+      width: "max-content",
+    });
+
+  // phenotype specific columns
+  if (props.category === "phenotype") {
+    extraCols.push(
+      {
+        id: "frequency",
+        key: "frequency",
+        heading: "Frequency",
+        sortable: true,
+      },
+      {
+        id: "onset",
+        key: "onset",
+        heading: "Onset",
+        sortable: true,
+      }
+    );
+  }
+
+  // publication specific columns
+  if (props.category === "publication")
+    extraCols.push(
+      {
+        id: "author",
+        key: "author",
+        heading: "Author",
+      },
+      {
+        id: "year",
+        key: "year",
+        heading: "Year",
+        width: "max-content",
+        align: "center",
+      },
+      {
+        id: "publisher",
+        key: "publisher",
+        heading: "Publisher",
+      }
+    );
+
+  // filter out extra columns with nothing in them (all rows for that col falsey)
+  // extraCols = extraCols.filter((col) =>
+  //   associations.value.some((association) => association[col.key || ""])
+  // );
+
+  // put divider to separate base cols from extra cols
+  if (extraCols[0]) extraCols.unshift({ id: "divider" });
+
+  return [...baseCols, ...extraCols];
+});
+
+// when user changes active filters
+function onFilterChange(colId: Col["id"], value: Options) {
+  if (activeFilters.value && activeFilters.value[colId]) {
+    activeFilters.value[colId] = value;
+    getAssociations(false);
+  }
+}
 
 // get table association data
-async function getAssociations() {
+async function getAssociations(
+  // whether to perform "fresh" search, without filters. set to true when
+  // category changing, false when filters changing.
+  fresh: boolean
+) {
   try {
     // loading...
     status.value = { code: "loading", text: "Loading association data" };
@@ -142,13 +262,22 @@ async function getAssociations() {
     const response = await getTabulatedAssociations(
       props.node.id,
       props.node.category,
-      props.category.id,
+      props.category,
       perPage.value,
       start.value,
-      search.value
+      search.value,
+      sort.value,
+      fresh ? undefined : filtersToQuery(availableFilters.value),
+      fresh ? undefined : filtersToQuery(activeFilters.value)
     );
     count.value = response.count;
     associations.value = response.associations;
+
+    if (fresh) {
+      // update filters based on facets from api
+      availableFilters.value = { ...response.facets };
+      activeFilters.value = { ...response.facets };
+    }
 
     // clear status
     status.value = null;
@@ -157,6 +286,10 @@ async function getAssociations() {
     status.value = error as ApiError;
     count.value = 0;
     associations.value = [];
+    if (fresh) {
+      availableFilters.value = {};
+      activeFilters.value = {};
+    }
   }
 }
 
@@ -175,7 +308,7 @@ async function download() {
   const response = await getTabulatedAssociations(
     props.node.id,
     props.node.category,
-    props.category.id,
+    props.category,
     max,
     0
   );
@@ -183,25 +316,16 @@ async function download() {
 }
 
 // get associations when category or table state changes
-watch([() => props.category, perPage, start, search], getAssociations);
+watch([() => props.category], () => getAssociations(true));
+watch([() => props.category, perPage, start, search, sort], () =>
+  getAssociations(false)
+);
 
 // get associations on load
-onMounted(getAssociations);
+onMounted(() => getAssociations(true));
 </script>
 
 <style lang="scss" scoped>
-.container {
-  position: relative;
-  width: 100%;
-
-  .status {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-  }
-}
 .arrow {
   color: $gray;
 }

--- a/src/views/node/SectionAssociations.vue
+++ b/src/views/node/SectionAssociations.vue
@@ -38,19 +38,20 @@
     >
       <!-- summary view of associations -->
       <template #summary>
-        <AssociationsSummary :node="node" :category="category" />
+        <AssociationsSummary :node="node" :category="category.id" />
       </template>
 
       <!-- table view of associations -->
       <template #table>
-        <AssociationsTable :node="node" :category="category" />
+        <AssociationsTable :node="node" :category="category.id" />
       </template>
     </AppTabs>
   </AppSection>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
+import { useRouter, useRoute } from "vue-router";
 import AppSelectSingle from "@/components/AppSelectSingle.vue";
 import { Option, Options } from "@/components/AppSelectSingle";
 import AppTabs from "@/components/AppTabs.vue";
@@ -58,6 +59,10 @@ import { Result as NodeResult } from "@/api/node-lookup";
 import { getAssociationName } from "@/api/categories";
 import AssociationsSummary from "./AssociationsSummary.vue";
 import AssociationsTable from "./AssociationsTable.vue";
+
+// route info
+const router = useRouter();
+const route = useRoute();
 
 interface Props {
   // current node
@@ -79,6 +84,25 @@ const categoryOptions = computed(
       count: association.count,
     }))
 );
+
+// update url from selected category
+watch(category, (value, prev) =>
+  // if category changed because it was set to default on page load, don't
+  // create new history entry
+  (prev ? router.push : router.replace)({
+    ...route,
+    query: { associations: category.value?.id },
+  })
+);
+
+// update selected category from url
+function setCategoryFromUrl() {
+  category.value = categoryOptions.value.find(
+    (option) => option.id === route.query.associations
+  );
+}
+watch(() => route.query.associations, setCategoryFromUrl);
+onMounted(setCategoryFromUrl);
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/node/SectionAssociations.vue
+++ b/src/views/node/SectionAssociations.vue
@@ -97,9 +97,10 @@ watch(category, (value, prev) =>
 
 // update selected category from url
 function setCategoryFromUrl() {
-  category.value = categoryOptions.value.find(
-    (option) => option.id === route.query.associations
-  );
+  if (route.query.associations)
+    category.value = categoryOptions.value.find(
+      (option) => option.id === route.query.associations
+    );
 }
 watch(() => route.query.associations, setCategoryFromUrl);
 onMounted(setCategoryFromUrl);

--- a/tests/e2e/specs/node.js
+++ b/tests/e2e/specs/node.js
@@ -83,9 +83,7 @@ it("Publication specific info shows", () => {
   cy.visit("/publication/MONDO:0007947");
 
   cy.contains("Publication");
-  cy.contains(
-    "Dimorphic effects of transforming growth factor-β signaling during aortic aneurysm progression in mice suggest a combinatorial therapy for Marfan syndrome."
-  );
+  cy.contains("Dimorphic effects of transforming growth factor-β signaling");
   cy.contains("Cook JR");
   cy.contains("Ramirez F");
   cy.contains("1. Arterioscler Thromb Vasc Biol. 2015 Apr;35(4):911-7.");
@@ -103,6 +101,9 @@ it("Summary association info shows", () => {
     .contains("Dural ectasia")
     .invoke("attr", "href")
     .should("equal", "/phenotype/HP:0100775");
+
+  cy.get(".result").contains("5 piece(s) of supporting evidence");
+  cy.get(".result").contains("4 piece(s) of supporting evidence");
 });
 
 it("Table association info shows", () => {
@@ -127,4 +128,30 @@ it("Association mode switching works", () => {
   cy.contains("button", "Phenotypes").trigger("click");
   cy.contains("[role='option'] > *", "Variants").trigger("click");
   cy.contains("th", "Variant");
+});
+
+it("Association table has extra metadata columns", () => {
+  cy.visit("/disease/MONDO:0007947");
+
+  cy.contains("Table").trigger("click");
+
+  cy.contains("tr", "Frequent")
+    .contains("Frequent")
+    .invoke("attr", "href")
+    .should("equal", "http://purl.obolibrary.org/obo/HP_0040282");
+
+  cy.contains("button", "Phenotypes").as("category");
+
+  cy.get("@category").trigger("click");
+  cy.contains("[role='option'] > *", "Variants").trigger("click");
+  cy.contains("td", "Mus musculus");
+  cy.contains("th", "Taxon").find("button").trigger("click");
+  cy.get("[role='listbox']").contains("Homo Sapiens");
+  cy.get("[role='listbox']").contains("Mus Musculus");
+
+  cy.get("@category").trigger("click");
+  cy.contains("[role='option'] > *", "Publications").trigger("click");
+  cy.contains("Author");
+  cy.contains("Year");
+  cy.contains("Publisher");
 });

--- a/tests/fixtures/node-associations.json
+++ b/tests/fixtures/node-associations.json
@@ -25,8 +25,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0100775",
         "label": "Dural ectasia",
@@ -280,8 +280,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0003179",
         "label": "Protrusio acetabuli",
@@ -517,8 +517,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0001083",
         "label": "Ectopia lentis",
@@ -754,8 +754,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0000501",
         "label": "Glaucoma",
@@ -991,8 +991,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0002705",
         "label": "High, narrow palate",
@@ -1149,8 +1149,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0004382",
         "label": "Mitral valve calcification",
@@ -1307,8 +1307,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0004326",
         "label": "Cachexia",
@@ -1465,8 +1465,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0002816",
         "label": "Genu recurvatum",
@@ -1612,8 +1612,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0004298",
         "label": "Abnormality of the abdominal wall",
@@ -1759,8 +1759,8 @@
       "subject_extensions": null,
       "object": {
         "taxon": {
-          "id": null,
-          "label": null
+          "id": "NCBITaxon:10090",
+          "label": "Mus musculus"
         },
         "id": "HP:0002996",
         "label": "Limited elbow movement",

--- a/tests/fixtures/node-associations.json
+++ b/tests/fixtures/node-associations.json
@@ -1897,6 +1897,38 @@
   "objects": null,
   "numFound": 89,
   "docs": null,
-  "facet_counts": {},
+  "facet_counts": {
+    "object_taxon_label": {
+      "Homo sapiens": 1541,
+      "Mus musculus": 3
+    },
+    "subject_closure": {
+      "BFO:0000001": 1544,
+      "BFO:0000002": 1544,
+      "BFO:0000016": 1544,
+      "BFO:0000017": 1544,
+      "BFO:0000020": 1544,
+      "COHD:253549": 1544,
+      "COHD:258540": 1544,
+      "COHD:374362": 1544,
+      "COHD:375252": 1544,
+      "COHD:379805": 1544,
+      "DOID:0050736": 1544,
+      "DOID:0050739": 1544,
+      "DOID:0080015": 1544,
+      "DOID:10124": 1544,
+      "DOID:10126": 1544,
+      "DOID:110": 1544,
+      "DOID:11830": 1544,
+      "DOID:1287": 1544,
+      "DOID:14323": 1544,
+      "DOID:1492": 1544,
+      "DOID:16": 1544,
+      "DOID:178": 1544,
+      "DOID:225": 1544,
+      "DOID:4": 1544,
+      "DOID:5614": 1544
+    }
+  },
   "highlighting": null
 }

--- a/tests/unit/AppSelectMulti.test.ts
+++ b/tests/unit/AppSelectMulti.test.ts
@@ -26,6 +26,14 @@ test("Opens/closes on click", async () => {
   expect(wrapper.find("[role='listbox']").exists()).toBe(false);
 });
 
+test("Opens/closes on keyboard", async () => {
+  const wrapper = mount(AppSelectMulti, { props });
+  const button = wrapper.find("button");
+  await button.trigger("click");
+  expect(wrapper.find("[role='listbox']").exists()).toBe(true);
+  await button.trigger("keydown", { key: "Escape" });
+});
+
 // expected type of emitted update:modelValue events
 type T = Array<unknown>;
 

--- a/tests/unit/AppTable.test.ts
+++ b/tests/unit/AppTable.test.ts
@@ -15,8 +15,6 @@ const props = {
       id: "score",
       key: "score",
       heading: "Score",
-      availableFilters: [{ id: "numbers" }, { id: "nulls" }],
-      activeFilters: [{ id: "numbers" }],
       sortable: true,
     },
     {
@@ -44,6 +42,8 @@ const props = {
   start: 1,
   total: 123,
   search: "",
+  availableFilters: { score: [{ id: "numbers" }, { id: "nulls" }] },
+  activeFilters: { score: [{ id: "numbers" }] },
 };
 
 test("Changes sort", async () => {
@@ -57,11 +57,15 @@ test("Changes sort", async () => {
 
 test("Changes filter", async () => {
   const wrapper = mount(AppTable, { props });
-  await wrapper.findAll("thead button").at(2)?.trigger("click");
+  const button = wrapper.findAll("thead button").at(2);
+  await button?.trigger("click");
   await wrapper.find("[role='option']").trigger("click");
-  expect(emitted(wrapper, "filter")).toEqual([1, []]);
+  await button?.trigger("keydown", { key: "Escape" });
+  expect(emitted(wrapper, "filter")).toEqual(["score", []]);
+  await button?.trigger("click");
   await wrapper.findAll("[role='option']").at(1)?.trigger("click");
-  expect(emitted(wrapper, "filter")).toEqual([1, [{ id: "nulls" }]]);
+  await button?.trigger("keydown", { key: "Escape" });
+  expect(emitted(wrapper, "filter")).toEqual(["score", [{ id: "nulls" }]]);
 });
 
 test("Changes per page", async () => {

--- a/tests/unit/node-search.test.ts
+++ b/tests/unit/node-search.test.ts
@@ -39,6 +39,6 @@ test("Returns formatted results", async () => {
   const { count, results, facets } = await getSearchResults("marfan");
   expect(count).toEqual(61);
   expect(results).toContainEqual(result);
-  expect(facets.category).toEqual(expect.arrayContaining(category));
-  expect(facets.taxon).toEqual(expect.arrayContaining(taxon));
+  expect(facets?.category).toEqual(expect.arrayContaining(category));
+  expect(facets?.taxon).toEqual(expect.arrayContaining(taxon));
 });


### PR DESCRIPTION
- abstract out some conversion between facets/filters/select-options into own api file and types
- more strongly type request func, change params format to be more flexible (and consistent with ROUTERe)
- add taxon, phenotype, and publication metadata to node associations lookup to include in associations table as extra columns
- make entrez summary lookup accept multiple ids at a time
- make app link component preserve rest of url when linking to hash
- add option to multi select component to hide counts
- return selected options from change even in multi select component, and always emit when closed
- add vertical divider option to table
- refactor table component to take sets of filters at the table level, not the column level. jives better with other filter use case. the diff here looks messy but not really that much changed.
- build in table status to table component itself
- rewrite how tab title constructed
- in node search, hide counts in multiselect dropdown if any filtering being done, to not mislead the user
- add "evidence count" to associations summary view on node page
- add filtering and sorting to the associations table view on node page, as far as the backend supports it (e.g. sorting by taxon doesn't seem to be possible)
- add extra metadata columns to associations table based on category of associations
- add tests and fixture data for metadata columns and filtering
- fix up and add to a few other tests

closes monarch-initiative/monarch-api#124 