### PR TITLE
Floating ui

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,10 +23,10 @@ module.exports = {
 
   /** rule overrides (KEEP THIS AS MINIMAL AS POSSIBLE) */
   rules: {
-    /** count v-tippy (which adds an accessible aria-label attribute) as accessible */
+    /** count v-tooltip (which adds an accessible aria-label attribute) as accessible */
     "vuejs-accessibility/anchor-has-content": [
       "error",
-      { accessibleDirectives: ["tippy"] },
+      { accessibleDirectives: ["tooltip"] },
     ],
     /**
      * allow nesting a control in a label without a for attribute (perfectly

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:lint": "vue-cli-service lint --no-fix && prettier --check \"**/*.{scss,js,ts,json,vue,svg,yaml}\" --no-error-on-unmatched-pattern"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
@@ -32,7 +33,7 @@
     "vue": "^3.2.37",
     "vue-inline-svg": "^3.1.0",
     "vue-router": "^4.0.16",
-    "vue-tippy": "^6.0.0-alpha.52",
+    "vue-tippy": "^6.0.0-alpha.62",
     "vuex": "^4.0.2",
     "wicg-inert": "^3.1.2"
   },

--- a/src/components/AppButton.vue
+++ b/src/components/AppButton.vue
@@ -5,13 +5,13 @@
 <template>
   <component
     :is="component"
+    ref="button"
     class="button"
     :to="to"
     :type="type"
     :data-design="design"
     :data-color="color"
     :data-text="!!text"
-    :data-notification="notification"
     @click="copy ? copyToClipboard() : click"
   >
     <span v-if="text">{{ text }}</span>
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { snackbar } from "./TheSnackbar";
 
 interface Props {
@@ -36,8 +36,6 @@ interface Props {
   design?: "normal" | "circle" | "small";
   /** color */
   color?: "primary" | "secondary" | "none";
-  /** whether to show little notification dot */
-  notification?: boolean;
   /** whether to copy text prop to clipboard on click */
   copy?: boolean;
   /** html button type attribute */
@@ -51,10 +49,12 @@ const props = withDefaults(defineProps<Props>(), {
   click: undefined,
   design: "normal",
   color: "primary",
-  notification: false,
   copy: false,
   type: "button",
 });
+
+/** element ref */
+const button = ref();
 
 /** copy text prop to clipboard */
 async function copyToClipboard() {
@@ -64,6 +64,8 @@ async function copyToClipboard() {
 
 /** type of component to render */
 const component = computed(() => (props.to ? "AppLink" : "button"));
+
+defineExpose({ button });
 </script>
 
 <style lang="scss" scoped>
@@ -149,17 +151,6 @@ const component = computed(() => (props.to ? "AppLink" : "button"));
     &:focus {
       color: $black;
     }
-  }
-
-  &[data-notification="true"]:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 5px;
-    height: 5px;
-    border-radius: 999px;
-    background: $error;
   }
 }
 </style>

--- a/src/components/AppMember.vue
+++ b/src/components/AppMember.vue
@@ -10,7 +10,7 @@
       </div>
       <AppIcon
         v-if="alumni"
-        v-tippy="'Alumni team member'"
+        v-tooltip="'Alumni team member'"
         icon="history"
         class="icon"
       />

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -24,7 +24,7 @@
           @touchstart.stop
         >
           <AppButton
-            v-tippy="'Close dialog (esc)'"
+            v-tooltip="'Close dialog (esc)'"
             class="close"
             design="circle"
             icon="times"

--- a/src/components/AppSelectMulti.vue
+++ b/src/components/AppSelectMulti.vue
@@ -57,6 +57,7 @@
         ref="dropdown"
         class="list"
         role="listbox"
+        :aria-labelledby="`select-${id}`"
         :aria-activedescendant="
           expanded ? `option-${id}-${highlighted}` : undefined
         "
@@ -68,8 +69,9 @@
           <div
             :id="`option-${id}--1`"
             class="option"
-            role="menuitem"
+            role="option"
             :aria-label="allSelected ? 'Deselect all' : 'Select all'"
+            :aria-selected="allSelected"
             :data-selected="allSelected"
             :data-highlighted="highlighted === -1"
             tabindex="0"

--- a/src/components/AppSelectMulti.vue
+++ b/src/components/AppSelectMulti.vue
@@ -10,124 +10,123 @@
 -->
 
 <template>
-  <div class="select-multi" :style="{ width: hasSlot ? '' : width }">
-    <!-- select button -->
-    <slot
-      v-if="hasSlot"
+  <div class="select-multi">
+    <!-- select button box -->
+    <component
+      :is="design === 'small' ? 'AppButton' : 'button'"
       :id="`select-${id}`"
+      ref="anchor"
+      :class="design === 'normal' ? 'box' : ''"
       :aria-label="name"
       :aria-expanded="expanded"
       :aria-controls="`list-${id}`"
       aria-haspopup="listbox"
-      :notification="!allSelected"
-      @click="onClick"
-      @keydown="onKeydown"
-      @blur="onBlur"
-    ></slot>
-    <button
-      v-else
-      :id="`select-${id}`"
-      class="button"
-      :aria-expanded="expanded"
-      :aria-controls="`list-${id}`"
-      aria-haspopup="listbox"
+      :data-notification="!allSelected"
+      icon="filter"
+      design="small"
       @click="onClick"
       @keydown="onKeydown"
       @blur="onBlur"
     >
-      <span class="button-label">
-        {{ name }}
-        <span class="button-more">
-          <template v-if="selected.length === 0">none selected</template>
-          <template v-else-if="selected.length === options.length">
-            all selected
-          </template>
-          <template v-else-if="selected.length === 1">
-            {{ options[selected[0]]?.id }}
-          </template>
-          <template v-else>{{ selected.length }} selected</template>
+      <template v-if="design === 'normal'">
+        <span class="box-label">
+          {{ name }}
+          <span class="box-more">
+            <template v-if="selected.length === 0">none selected</template>
+            <template v-else-if="selected.length === options.length">
+              all selected
+            </template>
+            <template v-else-if="selected.length === 1">
+              {{ options[selected[0]]?.id }}
+            </template>
+            <template v-else>{{ selected.length }} selected</template>
+          </span>
         </span>
-      </span>
-      <AppIcon
-        class="button-icon"
-        :icon="expanded ? 'angle-up' : 'angle-down'"
-      />
-    </button>
+        <AppIcon
+          class="button-icon"
+          :icon="expanded ? 'angle-up' : 'angle-down'"
+        />
+      </template>
+    </component>
 
     <!-- options list -->
-    <div
-      v-if="expanded"
-      :id="`list-${id}`"
-      class="list"
-      role="listbox"
-      :aria-activedescendant="
-        expanded ? `option-${id}-${highlighted}` : undefined
-      "
-      tabindex="0"
-      :data-slot="hasSlot"
-    >
-      <div class="grid">
-        <!-- select all -->
-        <div
-          :id="`option-${id}--1`"
-          class="option"
-          role="menuitem"
-          :aria-label="allSelected ? 'Deselect all' : 'Select all'"
-          :data-selected="allSelected"
-          :data-highlighted="highlighted === -1"
-          tabindex="0"
-          @click="() => toggleSelect(-1)"
-          @mouseenter="highlighted = -1"
-          @mousedown.prevent=""
-          @focusin="() => null"
-          @keydown="() => null"
-        >
-          <span class="option-icon">
-            <AppIcon :icon="allSelected ? 'square-check' : 'square'" />
-          </span>
-          <span class="option-label">All</span>
-          <span class="option-count"></span>
-        </div>
+    <Teleport to="body">
+      <div
+        v-if="expanded"
+        :id="`list-${id}`"
+        ref="dropdown"
+        class="list"
+        role="listbox"
+        :aria-activedescendant="
+          expanded ? `option-${id}-${highlighted}` : undefined
+        "
+        tabindex="0"
+        :style="style"
+      >
+        <div class="grid">
+          <!-- select all -->
+          <div
+            :id="`option-${id}--1`"
+            class="option"
+            role="menuitem"
+            :aria-label="allSelected ? 'Deselect all' : 'Select all'"
+            :data-selected="allSelected"
+            :data-highlighted="highlighted === -1"
+            tabindex="0"
+            @click="() => toggleSelect(-1)"
+            @mouseenter="highlighted = -1"
+            @mousedown.prevent=""
+            @focusin="() => null"
+            @keydown="() => null"
+          >
+            <span class="option-icon">
+              <AppIcon :icon="allSelected ? 'square-check' : 'square'" />
+            </span>
+            <span class="option-label">All</span>
+            <span class="option-count"></span>
+          </div>
 
-        <div class="option-spacer"></div>
+          <div class="option-spacer"></div>
 
-        <!-- options -->
-        <div
-          v-for="(option, index) in options"
-          :id="`option-${id}-${index}`"
-          :key="index"
-          class="option"
-          role="option"
-          :aria-selected="selected.includes(index)"
-          :data-selected="selected.includes(index)"
-          :data-highlighted="index === highlighted"
-          tabindex="0"
-          @click="(event) => toggleSelect(index, event.shiftKey)"
-          @mouseenter="highlighted = index"
-          @mousedown.prevent=""
-          @focusin="() => null"
-          @keydown="() => null"
-        >
-          <span class="option-icon">
-            <AppIcon
-              :icon="selected.includes(index) ? 'square-check' : 'square'"
-            />
-          </span>
-          <span class="option-label">{{ option.id }}</span>
-          <span class="option-count">
-            {{ showCounts ? option.count : "" }}
-          </span>
+          <!-- options -->
+          <div
+            v-for="(option, index) in options"
+            :id="`option-${id}-${index}`"
+            :key="index"
+            class="option"
+            role="option"
+            :aria-selected="selected.includes(index)"
+            :data-selected="selected.includes(index)"
+            :data-highlighted="index === highlighted"
+            tabindex="0"
+            @click="(event) => toggleSelect(index, event.shiftKey)"
+            @mouseenter="highlighted = index"
+            @mousedown.prevent=""
+            @focusin="() => null"
+            @keydown="() => null"
+          >
+            <span class="option-icon">
+              <AppIcon
+                :icon="selected.includes(index) ? 'square-check' : 'square'"
+              />
+            </span>
+            <span class="option-label">{{ option.id }}</span>
+            <span class="option-count">
+              {{ showCounts ? option.count : "" }}
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, useSlots, watch } from "vue";
+import { ref, computed, watch, nextTick } from "vue";
 import { isEqual, uniqueId } from "lodash";
 import { Options } from "./AppSelectMulti";
 import { wrap } from "@/util/math";
+import { useFloating } from "@/util/composables";
 
 interface Props {
   /** two-way bound selected items state */
@@ -136,13 +135,16 @@ interface Props {
   name: string;
   /** list of options to show */
   options: Options;
-  /** width style of button */
-  width?: string;
   /** whether to show count col */
   showCounts?: boolean;
+  /** visual design */
+  design?: "normal" | "small";
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  showCounts: true,
+  design: "normal",
+});
 
 interface Emits {
   /** two-way bound selected items state */
@@ -165,6 +167,19 @@ const selected = ref<Array<number>>([]);
 const last = ref<Array<number>>([]);
 /** index of option that is highlighted */
 const highlighted = ref(0);
+
+/** anchor element */
+const anchor = ref();
+/** dropdown element */
+const dropdown = ref();
+/** get dropdown position */
+const { calculate, style } = useFloating();
+/** recompute position after opened */
+watch(expanded, async () => {
+  await nextTick();
+  if (expanded.value)
+    calculate(anchor.value?.button || anchor.value, dropdown.value);
+});
 
 function open() {
   /** open dropdown */
@@ -291,9 +306,6 @@ watch(highlighted, () =>
     ?.scrollIntoView({ block: "nearest" })
 );
 
-/** if has slot */
-const hasSlot = computed(() => !!useSlots().default);
-
 /** are all options selected */
 const allSelected = computed(
   () => selected.value.length === props.options.length
@@ -307,7 +319,7 @@ const allSelected = computed(
   text-transform: capitalize;
 }
 
-.button {
+.box {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -318,19 +330,17 @@ const allSelected = computed(
   background: $light-gray;
 }
 
-.button-label {
+.box-label {
   flex-grow: 1;
   text-align: left;
 }
 
-.button-more {
+.box-more {
   color: $dark-gray;
   margin-left: 10px;
 }
 
 .list {
-  position: absolute;
-  min-width: 100%;
   max-width: 90vw;
   max-height: 300px;
   overflow-x: auto;
@@ -338,12 +348,6 @@ const allSelected = computed(
   background: $white;
   box-shadow: $shadow;
   z-index: 2;
-}
-
-.list[data-slot="true"] {
-  max-width: unset;
-  left: 50%;
-  transform: translateX(-50%);
 }
 
 .grid {

--- a/src/components/AppSelectTags.vue
+++ b/src/components/AppSelectTags.vue
@@ -15,7 +15,7 @@
       <AppButton
         v-for="(option, index) in selected"
         :key="index"
-        v-tippy="`Deselect ${option.id}`"
+        v-tooltip="`Deselect ${option.id}`"
         design="circle"
         :text="option.name || option.id"
         icon="xmark"
@@ -28,7 +28,7 @@
         <!-- input box -->
         <input
           v-model="search"
-          v-tippy="{ content: tooltip, offset: [20, 20] }"
+          v-tooltip="{ content: tooltip, offset: [20, 20] }"
           :placeholder="placeholder"
           role="combobox"
           :aria-label="name"
@@ -48,7 +48,7 @@
         <span class="meta">
           <!-- copy ids -->
           <AppButton
-            v-tippy="`Copy selected values`"
+            v-tooltip="`Copy selected values`"
             design="small"
             icon="copy"
             @click="copy"
@@ -56,7 +56,7 @@
           {{ " " }}
           <!-- clear box -->
           <AppButton
-            v-tippy="`Clear selected values`"
+            v-tooltip="`Clear selected values`"
             design="small"
             icon="times"
             @click="clear"

--- a/src/components/AppSelectTags.vue
+++ b/src/components/AppSelectTags.vue
@@ -9,7 +9,7 @@
 
 <template>
   <div class="select-tags">
-    <!-- box -->
+    <!-- select box -->
     <div class="box" :data-focused="focused">
       <!-- deselect button -->
       <AppButton

--- a/src/components/AppStatus.vue
+++ b/src/components/AppStatus.vue
@@ -4,7 +4,7 @@
 
 <template>
   <AppLink
-    v-tippy="code === 'error' ? 'See dev console for more details' : ''"
+    v-tooltip="code === 'error' ? 'See dev console for more details' : ''"
     :to="link || ''"
     class="status"
     :data-code="code || ''"

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -37,7 +37,7 @@
                 </span>
                 <AppButton
                   v-if="col.sortable"
-                  v-tippy="'Sort by ' + col.heading"
+                  v-tooltip="'Sort by ' + col.heading"
                   :icon="
                     'arrow-' + (sort?.id === col.id ? sort?.direction : 'down')
                   "
@@ -61,7 +61,7 @@
                   @change="(value) => emitFilter(col.id, value)"
                 >
                   <AppButton
-                    v-tippy="'Filter by ' + col.heading"
+                    v-tooltip="'Filter by ' + col.heading"
                     icon="filter"
                     design="small"
                     v-bind="kebabify(slotProps)"
@@ -125,14 +125,14 @@
         <div>
           <template v-if="showControls">
             <AppButton
-              v-tippy="'Go to first page'"
+              v-tooltip="'Go to first page'"
               :disabled="start <= 0"
               icon="angle-double-left"
               design="small"
               @click="clickFirst"
             />
             <AppButton
-              v-tippy="'Go to previous page'"
+              v-tooltip="'Go to previous page'"
               :disabled="start - perPage < 0"
               icon="angle-left"
               design="small"
@@ -148,14 +148,14 @@
           <span v-else>no data</span>
           <template v-if="showControls">
             <AppButton
-              v-tippy="'Go to next page'"
+              v-tooltip="'Go to next page'"
               :disabled="start + perPage > total"
               icon="angle-right"
               design="small"
               @click="clickNext"
             />
             <AppButton
-              v-tippy="'Go to last page'"
+              v-tooltip="'Go to last page'"
               :disabled="start + perPage > total"
               icon="angle-double-right"
               design="small"
@@ -168,20 +168,22 @@
         <div>
           <AppInput
             v-if="showControls"
-            v-tippy="'Search table data'"
+            v-tooltip="'Search table data'"
             class="search"
             icon="search"
             :model-value="search"
             @change="emitSearch"
           />
           <AppButton
-            v-tippy="'Download table data'"
+            v-tooltip="'Download table data'"
             icon="download"
             design="small"
             @click="emitDownload"
           />
           <AppButton
-            v-tippy="expanded ? 'Collapse table' : 'Expand table to full width'"
+            v-tooltip="
+              expanded ? 'Collapse table' : 'Expand table to full width'
+            "
             :icon="expanded ? 'minimize' : 'maximize'"
             design="small"
             @click="expanded = !expanded"

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -54,19 +54,13 @@
                     activeFilters[col.id] &&
                     availableFilters[col.id]?.length
                   "
-                  v-slot="slotProps"
+                  v-tooltip="'Filter by ' + col.heading"
                   :name="'Filter by ' + col.heading"
                   :options="availableFilters[col.id]"
                   :model-value="activeFilters[col.id]"
+                  design="small"
                   @change="(value) => emitFilter(col.id, value)"
-                >
-                  <AppButton
-                    v-tooltip="'Filter by ' + col.heading"
-                    icon="filter"
-                    design="small"
-                    v-bind="kebabify(slotProps)"
-                  />
-                </AppSelectMulti>
+                />
               </th>
             </tr>
           </thead>
@@ -202,7 +196,6 @@ import AppInput from "./AppInput.vue";
 import AppSelectMulti from "./AppSelectMulti.vue";
 import AppSelectSingle from "./AppSelectSingle.vue";
 import { Options } from "./AppSelectMulti";
-import { kebabify } from "@/util/object";
 import { Filters } from "@/api/facets";
 import { closeToc } from "./TheTableOfContents";
 

--- a/src/components/AppTabs.vue
+++ b/src/components/AppTabs.vue
@@ -11,7 +11,7 @@
       v-for="(tab, index) in tabs"
       :id="`tab-${id}-${tab.id}`"
       :key="index"
-      v-tippy="tab.tooltip"
+      v-tooltip="tab.tooltip"
       :text="tab.text"
       :icon="tab.icon"
       design="circle"

--- a/src/components/AppUpload.vue
+++ b/src/components/AppUpload.vue
@@ -4,7 +4,7 @@
 
 <template>
   <AppButton
-    v-tippy="'Choose or drag & drop a file'"
+    v-tooltip="'Choose or drag & drop a file'"
     class="button"
     text="Upload"
     icon="upload"

--- a/src/components/TheFloatButtons.vue
+++ b/src/components/TheFloatButtons.vue
@@ -7,7 +7,7 @@
     <transition name="fade">
       <AppButton
         v-if="showJump"
-        v-tippy="'Jump to top of page'"
+        v-tooltip="'Jump to top of page'"
         design="circle"
         class="button"
         icon="angle-up"
@@ -17,7 +17,7 @@
     <transition name="fade">
       <AppButton
         v-if="showFeedback"
-        v-tippy="'Give us feedback on this page!'"
+        v-tooltip="'Give us feedback on this page!'"
         design="circle"
         class="button"
         icon="comment"

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -5,16 +5,16 @@
 <template>
   <footer>
     <div class="social">
-      <AppLink v-tippy="'Newsletter'" to="https://substack.com/">
+      <AppLink v-tooltip="'Newsletter'" to="https://substack.com/">
         <AppIcon icon="envelope-open-text" />
       </AppLink>
-      <AppLink v-tippy="'GitHub'" to="https://github.com/monarch-initiative">
+      <AppLink v-tooltip="'GitHub'" to="https://github.com/monarch-initiative">
         <AppIcon icon="github" />
       </AppLink>
-      <AppLink v-tippy="'Twitter'" to="https://twitter.com/MonarchInit">
+      <AppLink v-tooltip="'Twitter'" to="https://twitter.com/MonarchInit">
         <AppIcon icon="twitter" />
       </AppLink>
-      <AppLink v-tippy="'Blog'" to="https://medium.com/@MonarchInit">
+      <AppLink v-tooltip="'Blog'" to="https://medium.com/@MonarchInit">
         <AppIcon icon="blog" />
       </AppLink>
     </div>

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -11,7 +11,7 @@
     <div class="title" :title="app.version">
       <!-- logo image and text -->
       <AppLink
-        v-tippy="home ? '' : 'Homepage'"
+        v-tooltip="home ? '' : 'Homepage'"
         :to="home ? '' : '/'"
         class="logo"
         :data-home="home"
@@ -25,7 +25,9 @@
 
       <!-- nav toggle button -->
       <button
-        v-tippy="expanded ? 'Close navigation menu' : 'Expand navigation menu'"
+        v-tooltip="
+          expanded ? 'Close navigation menu' : 'Expand navigation menu'
+        "
         class="button"
         :aria-expanded="expanded"
         @click="expanded = !expanded"
@@ -37,21 +39,21 @@
     <!-- navigation bar -->
     <nav :data-home="home" :data-expanded="expanded">
       <AppLink
-        v-tippy="'Dive right in and use Monarch'"
+        v-tooltip="'Dive right in and use Monarch'"
         class="link"
         to="/explore"
       >
         Explore
       </AppLink>
       <AppLink
-        v-tippy="'Citing, licensing, sources, and other info'"
+        v-tooltip="'Citing, licensing, sources, and other info'"
         class="link"
         to="/about"
       >
         About
       </AppLink>
       <AppLink
-        v-tippy="'Feedback, docs, guides, contact, and more'"
+        v-tooltip="'Feedback, docs, guides, contact, and more'"
         class="link"
         to="/help"
       >

--- a/src/components/TheTableOfContents.vue
+++ b/src/components/TheTableOfContents.vue
@@ -14,7 +14,7 @@
     <!-- toggle button -->
     <div class="title">
       <button
-        v-tippy="
+        v-tooltip="
           expanded ? 'Close table of contents' : 'Expand table of contents'
         "
         class="title-button"
@@ -48,7 +48,7 @@
       <!-- options -->
       <AppCheckbox
         v-model="oneAtATime"
-        v-tippy="'Only show one section at a time'"
+        v-tooltip="'Only show one section at a time'"
         text="Show single section"
       />
     </template>

--- a/src/global/plugins.ts
+++ b/src/global/plugins.ts
@@ -4,7 +4,7 @@ import store from "@/store";
 import tippy from "vue-tippy";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/dist/border.css";
-import { options } from "./tippy";
+import { options } from "./tooltip";
 
 /** list of global plugins and their options */
 const plugins: Array<[Plugin, unknown]> = [

--- a/src/global/styles.scss
+++ b/src/global/styles.scss
@@ -135,6 +135,23 @@ strong {
   font-weight: 500;
 }
 
+/** notification dot */
+
+[data-notification="true"] {
+  position: relative;
+}
+
+[data-notification="true"]:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: $error;
+}
+
 /** tooltips */
 
 .tippy-box {

--- a/src/global/tooltip.ts
+++ b/src/global/tooltip.ts
@@ -29,8 +29,8 @@ const onShow = (instance: Instance): boolean =>
 const onHide = (): boolean => true;
 
 export const options = {
-  directive: "tippy",
-  component: "tippy",
+  directive: "tooltip",
+  component: "tooltip",
   defaultProps: {
     delay: 100,
     duration: 200,

--- a/src/util/composables.ts
+++ b/src/util/composables.ts
@@ -1,4 +1,5 @@
-import { ref, shallowRef } from "vue";
+import { CSSProperties, ref, shallowRef } from "vue";
+import { computePosition, flip, shift, size } from "@floating-ui/dom";
 
 /**
  * inspired by react-query. simple query manager/wrapper for making queries in
@@ -78,4 +79,41 @@ export const useQuery = <Data, Args extends Array<unknown>>(
   }
 
   return { query, data, isLoading, isError, isSuccess };
+};
+
+/** use floating-ui to position dropdown */
+export const useFloating = () => {
+  /** style of dropdown */
+  const style = ref<CSSProperties>({
+    position: "absolute",
+    left: "0px",
+    top: "0px",
+    minWidth: "0px",
+  });
+
+  /** func to recompute position on command */
+  async function calculate(anchor?: HTMLElement, dropdown?: HTMLElement) {
+    if (!anchor || !dropdown) return;
+
+    /** floating-ui options */
+    const options = {
+      middleware: [
+        flip(),
+        shift({ padding: 5 }),
+        size({
+          /** update min width based on target width */
+          apply: ({ rects }) =>
+            (style.value.minWidth = rects.reference.width + "px"),
+        }),
+      ],
+    };
+    /** use floating-ui to compute position of dropdown */
+    const { x, y } = await computePosition(anchor, dropdown, options);
+
+    /** set style from position */
+    style.value.left = x + "px";
+    style.value.top = y + "px";
+  }
+
+  return { calculate, style };
 };

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -1,4 +1,4 @@
-import { kebabCase, mapKeys, merge } from "lodash";
+import { merge } from "lodash";
 
 /** object with id field */
 type Obj = { id?: string };
@@ -31,17 +31,6 @@ export const mergeArrays = (
   /** convert object back to array */
   return Object.values(result);
 };
-
-/**
- * convert attributes of a vue slot props object to kebab-case.
- * https://github.com/vuejs/core/issues/5477
- */
-export const kebabify = (
-  object: Record<string, unknown>
-): Record<string, unknown> =>
-  mapKeys(object, (value, key: string) =>
-    key.includes("on") ? key : kebabCase(key)
-  );
 
 /** rename key in object in place */
 export const renameKey = (

--- a/src/views/PageTestbed.vue
+++ b/src/views/PageTestbed.vue
@@ -87,6 +87,7 @@
       v-slot="props"
       v-model="multiSelectValue"
       name="Category"
+      design="small"
       :options="multiSelectOptions"
     >
       <AppButton

--- a/src/views/PageTestbed.vue
+++ b/src/views/PageTestbed.vue
@@ -90,7 +90,7 @@
       :options="multiSelectOptions"
     >
       <AppButton
-        v-tippy="'Test button'"
+        v-tooltip="'Test button'"
         icon="filter"
         v-bind="props"
         design="small"
@@ -117,7 +117,7 @@
       <AppButton
         v-for="(props, colIndex) of row"
         :key="colIndex"
-        v-tippy="'Test button'"
+        v-tooltip="'Test button'"
         to="/"
         v-bind="props"
         @click="log"

--- a/src/views/about/PageSources.vue
+++ b/src/views/about/PageSources.vue
@@ -39,7 +39,7 @@
         <AppFlex>
           <AppButton
             v-if="source.link"
-            v-tippy="'Homepage or repository for this source'"
+            v-tooltip="'Homepage or repository for this source'"
             design="small"
             icon="home"
             text="Home"
@@ -47,7 +47,7 @@
           />
           <AppButton
             v-if="source.license"
-            v-tippy="'Link to licensing information for this source'"
+            v-tooltip="'Link to licensing information for this source'"
             design="small"
             icon="balance-scale"
             text="License"
@@ -55,7 +55,7 @@
           />
           <AppButton
             v-if="source.distribution"
-            v-tippy="'Download Resource Description Framework file'"
+            v-tooltip="'Download Resource Description Framework file'"
             design="small"
             icon="download"
             text="RDF"
@@ -63,7 +63,7 @@
           />
           <AppButton
             v-if="source.date"
-            v-tippy="'Date when this source was ingested into Monarch'"
+            v-tooltip="'Date when this source was ingested into Monarch'"
             design="small"
             color="secondary"
             icon="calendar-alt"
@@ -89,7 +89,7 @@
           <AppLink
             v-for="(file, fileIndex) in source.files"
             :key="fileIndex"
-            v-tippy="breakUrl(file)"
+            v-tooltip="breakUrl(file)"
             :to="file"
             class="truncate"
           >

--- a/src/views/about/PageTeam.vue
+++ b/src/views/about/PageTeam.vue
@@ -27,7 +27,7 @@
       {{ group.name }}
       <AppIcon
         v-if="group.alumni"
-        v-tippy="'Alumni group'"
+        v-tooltip="'Alumni group'"
         class="icon"
         icon="history"
       />

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -34,7 +34,7 @@
         <AppSelectMulti
           v-if="filter.length"
           v-model="activeFilters[name]"
-          v-tippy="`${startCase(name)} filter`"
+          v-tooltip="`${startCase(name)} filter`"
           :name="`${name}`"
           :options="availableFilters[name]"
           :show-counts="showCounts"
@@ -64,7 +64,7 @@
     >
       <div class="title">
         <AppIcon
-          v-tippy="startCase(result.category)"
+          v-tooltip="startCase(result.category)"
           :icon="`category-${kebabCase(result.category)}`"
           class="type"
         />
@@ -75,7 +75,7 @@
           <span v-html="result.highlight"></span>
         </AppLink>
         <AppButton
-          v-tippy="'Node ID (click to copy)'"
+          v-tooltip="'Node ID (click to copy)'"
           class="id"
           :text="result.id"
           icon="hashtag"
@@ -84,7 +84,7 @@
           color="secondary"
         />
       </div>
-      <p v-tippy="'Click to expand'" class="truncate-3" tabindex="0">
+      <p v-tooltip="'Click to expand'" class="truncate-3" tabindex="0">
         {{ result.description || "No description available" }}
       </p>
       <p v-if="result.altNames?.length" class="names truncate-1" tabindex="0">
@@ -106,7 +106,7 @@
           <button
             v-for="pageNumber of list"
             :key="pageNumber"
-            v-tippy="`Go to page ${pageNumber + 1} of results`"
+            v-tooltip="`Go to page ${pageNumber + 1} of results`"
             class="page-button"
             :disabled="pageNumber === page"
             @click="page = pageNumber"

--- a/src/views/explore/PhenotypeExplorer.vue
+++ b/src/views/explore/PhenotypeExplorer.vue
@@ -76,7 +76,7 @@
       >
         <!-- ring score -->
         <AppRing
-          v-tippy="'Similarity score'"
+          v-tooltip="'Similarity score'"
           :score="match.score"
           :min="comparison.minScore"
           :max="comparison.maxScore"
@@ -86,7 +86,7 @@
           <!-- primary match info -->
           <div class="primary truncate">
             <AppIcon
-              v-tippy="startCase(match.category)"
+              v-tooltip="startCase(match.category)"
               :icon="`category-${match.category}`"
             />
 

--- a/src/views/explore/TextAnnotator.vue
+++ b/src/views/explore/TextAnnotator.vue
@@ -36,7 +36,7 @@
 
     <!-- results -->
     <p v-if="annotations.length">
-      <tippy
+      <tooltip
         v-for="({ text, tokens }, annotationIndex) in annotations"
         :key="annotationIndex"
         :interactive="true"
@@ -54,14 +54,14 @@
             </template>
           </div>
         </template>
-      </tippy>
+      </tooltip>
     </p>
 
     <!-- actions -->
     <AppFlex v-if="annotations.length">
       <AppButton text="Download" icon="download" @click="download" />
       <AppButton
-        v-tippy="
+        v-tooltip="
           'Send any annotations above that are phenotypes to Phenotype Explorer'
         "
         text="Analyze Phenotypes"
@@ -84,7 +84,7 @@ import { annotateText } from "@/api/text-annotator";
 import { downloadJson } from "@/util/download";
 import { setData } from "@/router";
 import { useRouter } from "vue-router";
-import { appendToBody } from "@/global/tippy";
+import { appendToBody } from "@/global/tooltip";
 import { useQuery } from "@/util/composables";
 
 /** route info */

--- a/src/views/node/AssociationsSummary.vue
+++ b/src/views/node/AssociationsSummary.vue
@@ -60,7 +60,7 @@
       </AppFlex>
 
       <AppButton
-        v-tippy="
+        v-tooltip="
           association.id === selectedAssociation?.id
             ? 'Viewing supporting evidence. Click again to hide.'
             : 'View supporting evidence for this association'

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -59,7 +59,7 @@
     <!-- button to show evidence -->
     <template #evidence="{ cell, row }">
       <AppButton
-        v-tippy="
+        v-tooltip="
           row.id === selectedAssociation?.id
             ? 'Viewing supporting evidence. Click again to hide.'
             : 'View supporting evidence for this association'

--- a/src/views/node/EvidenceViewer.vue
+++ b/src/views/node/EvidenceViewer.vue
@@ -162,7 +162,7 @@
               >{{ publication.name }}</AppLink
             >
             <template v-if="cell.length > 1">
-              <tippy :interactive="true" :append-to="appendToBody">
+              <tooltip :interactive="true" :append-to="appendToBody">
                 <span>and {{ cell.length - 1 }} more...</span>
                 <template #content>
                   <AppFlex h-align="left" gap="tiny">
@@ -174,7 +174,7 @@
                     >
                   </AppFlex>
                 </template>
-              </tippy>
+              </tooltip>
             </template>
           </AppFlex>
         </template>
@@ -217,7 +217,7 @@ import { Node } from "@/api/node-lookup";
 import { scrollToElement } from "@/router";
 import { getAssociationEvidence } from "@/api/association-evidence";
 import { breakUrl } from "@/util/string";
-import { appendToBody } from "@/global/tippy";
+import { appendToBody } from "@/global/tooltip";
 import { waitFor } from "@/util/dom";
 import { Association } from "@/api/node-associations";
 import { useQuery } from "@/util/composables";

--- a/src/views/node/SectionDetails.vue
+++ b/src/views/node/SectionDetails.vue
@@ -18,7 +18,7 @@
           <AppLink
             v-for="(inheritance, index) of node.inheritance"
             :key="index"
-            v-tippy="inheritance.id"
+            v-tooltip="inheritance.id"
             :to="inheritance.link"
             >{{ inheritance.name }}</AppLink
           >
@@ -36,7 +36,7 @@
         :blank="!node.taxon?.id"
         title="Taxon"
       >
-        <AppLink v-tippy="node?.taxon?.id" :to="node.taxon?.link || ''">{{
+        <AppLink v-tooltip="node?.taxon?.id" :to="node.taxon?.link || ''">{{
           node.taxon?.name
         }}</AppLink>
       </AppDetail>

--- a/src/views/node/SectionHierarchy.vue
+++ b/src/views/node/SectionHierarchy.vue
@@ -21,7 +21,7 @@
         icon="angle-up"
         :blank="!hierarchy.superClasses.length"
         :big="true"
-        :v-tippy="`Nodes that are &quot;parents&quot; of this node`"
+        :v-tooltip="`Nodes that are &quot;parents&quot; of this node`"
       >
         <AppFlex class="flex" h-align="left" gap="small">
           <AppLink
@@ -39,7 +39,7 @@
         icon="equals"
         :blank="!hierarchy.equivalentClasses.length"
         :big="true"
-        :v-tippy="`Nodes that are &quot;siblings&quot; of this node`"
+        :v-tooltip="`Nodes that are &quot;siblings&quot; of this node`"
       >
         <AppFlex class="flex" h-align="left" gap="small">
           <AppLink
@@ -57,7 +57,7 @@
         icon="angle-down"
         :blank="!hierarchy.subClasses.length"
         :big="true"
-        :v-tippy="`Nodes that are &quot;children&quot; of this node`"
+        :v-tooltip="`Nodes that are &quot;children&quot; of this node`"
       >
         <AppFlex class="flex" h-align="left" gap="small">
           <AppLink

--- a/src/views/node/SectionOverview.vue
+++ b/src/views/node/SectionOverview.vue
@@ -33,7 +33,7 @@
       <!-- paragraph description -->
       <AppDetail :blank="!node.description" title="Description" :big="true">
         <p
-          v-tippy="'Click to expand'"
+          v-tooltip="'Click to expand'"
           class="description truncate-10"
           tabindex="0"
           v-html="node.description.trim()"

--- a/src/views/node/SectionTitle.vue
+++ b/src/views/node/SectionTitle.vue
@@ -13,13 +13,13 @@
       </AppHeading>
       <AppFlex>
         <AppButton
-          v-tippy="'The category/type of this node'"
+          v-tooltip="'The category/type of this node'"
           design="small"
           color="secondary"
           :text="node.category"
         />
         <AppButton
-          v-tippy="'The ID of this node. Click to copy.'"
+          v-tooltip="'The ID of this node. Click to copy.'"
           design="small"
           color="secondary"
           icon="hashtag"
@@ -28,7 +28,7 @@
         />
         <span
           v-if="node.id !== node.originalId"
-          v-tippy="
+          v-tooltip="
             'The original ID you visited, which resolved to a different ID.'
           "
           class="original-id"

--- a/tests/axe/pages.test.ts
+++ b/tests/axe/pages.test.ts
@@ -1,18 +1,14 @@
 import { nextTick } from "vue";
 import router, { routes } from "@/router";
-import { axe, toHaveNoViolations } from "jest-axe";
+import { axe } from "jest-axe";
 import { mount, apiCall } from "../setup";
 import App from "@/App.vue";
-
-/** add axe to jest */
-expect.extend(toHaveNoViolations);
 
 /** get list of page paths to check */
 const pages = routes
   /** exclude fuzzy-matched paths and other specific pages */
   .filter(
-    (route) =>
-      !["Node", "NodeRaw", "NotFound", "Testbed"].includes(String(route.name))
+    (route) => !["Node", "NodeRaw", "NotFound"].includes(String(route.name))
   )
   /** paths to navigate to */
   .map((route) => route.path)
@@ -40,8 +36,19 @@ test(
       await apiCall();
 
       /** analyze rendered html with axe */
-      const results = await axe(wrapper.element);
-      expect(results).toHaveNoViolations();
+      expect(await axe(wrapper.element)).toHaveNoViolations();
+
+      /** special checks on testbed page */
+      if (page === "Testbed") {
+        await wrapper.find(".select-single button").trigger("click");
+        expect(await axe(wrapper.element)).toHaveNoViolations();
+
+        await wrapper.find(".select-multi button").trigger("click");
+        expect(await axe(wrapper.element)).toHaveNoViolations();
+
+        await wrapper.find(".select-tags input").trigger("focus");
+        expect(await axe(wrapper.element)).toHaveNoViolations();
+      }
     }
   },
   /** allow plenty of seconds per page */

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,7 @@ import {
   VueWrapper,
   mount as vueMount,
 } from "@vue/test-utils";
+import { toHaveNoViolations } from "jest-axe";
 import { setupServer } from "msw/node";
 import fetch from "node-fetch";
 import { cloneDeep } from "lodash";
@@ -58,6 +59,9 @@ beforeEach(async () => {
 afterAll(async () => {
   await sleep();
 });
+
+/** add axe to jest */
+expect.extend(toHaveNoViolations);
 
 /** setup mock-service-worker for node.js (jest) */
 const server = setupServer(...handlers);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -105,7 +105,7 @@ export const mount = <Component>(
   options.props = cloneDeep(props);
 
   /** standard globals */
-  options.global = { components, plugins };
+  options.global = { components, plugins, stubs: { teleport: true } };
 
   // eslint-disable-next-line
   const wrapper: Wrapper = vueMount(component, options as MountingOptions<any>);

--- a/tests/unit/AppSelectMulti.test.ts
+++ b/tests/unit/AppSelectMulti.test.ts
@@ -43,11 +43,11 @@ test("Selects by click", async () => {
   const wrapper = mount(AppSelectMulti, props, vModel);
   const button = wrapper.find("button");
   await button.trigger("click");
-  await wrapper.findAll("[role='option']").at(0)?.trigger("click");
+  await wrapper.findAll("[role='option']").at(1)?.trigger("click");
   expect(emitted<T>(wrapper)[0].length).toEqual(2);
-  await wrapper.findAll("[role='option']").at(2)?.trigger("click");
-  expect(emitted<T>(wrapper)[0].length).toEqual(3);
   await wrapper.findAll("[role='option']").at(3)?.trigger("click");
+  expect(emitted<T>(wrapper)[0].length).toEqual(3);
+  await wrapper.findAll("[role='option']").at(4)?.trigger("click");
   expect(emitted<T>(wrapper)[0].length).toEqual(4);
 });
 
@@ -71,7 +71,7 @@ test("Selects all by click", async () => {
   const wrapper = mount(AppSelectMulti, props, vModel);
   const button = wrapper.find("button");
   await button.trigger("click");
-  const option = wrapper.find("[role='menuitem']");
+  const option = wrapper.find("[role='option']");
   await option.trigger("click");
   expect(emitted<T>(wrapper)[0].length).toEqual(4);
   await option.trigger("click");

--- a/tests/unit/AppTable.test.ts
+++ b/tests/unit/AppTable.test.ts
@@ -59,11 +59,11 @@ test("Changes filter", async () => {
   const wrapper = mount(AppTable, props);
   const button = wrapper.findAll("thead button").at(2);
   await button?.trigger("click");
-  await wrapper.find("[role='option']").trigger("click");
+  await wrapper.findAll("[role='option']").at(1)?.trigger("click");
   await button?.trigger("keydown", { key: "Escape" });
   expect(emitted(wrapper, "filter")).toEqual(["score", []]);
   await button?.trigger("click");
-  await wrapper.findAll("[role='option']").at(1)?.trigger("click");
+  await wrapper.findAll("[role='option']").at(2)?.trigger("click");
   await button?.trigger("keydown", { key: "Escape" });
   expect(emitted(wrapper, "filter")).toEqual(["score", [{ id: "nulls" }]]);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.0.tgz#ec1d31f54c72dd0460276e2149e59bd13c0f01f6"
+  integrity sha512-sm3nW0hHAxTv3gRDdCH8rNVQxijF+qPFo5gAeXCErRjKC7Qc28lIQ3R9Vd7Gw+KgwfA7RhRydDFuGeI0peGq7A==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.0.tgz#66923a56755b6cb7a5958ecf25fe293912672d65"
+  integrity sha512-PMqJvY5Fae8HVQgUqM+lidprS6p9LSvB0AUhCdYKqr3YCaV+WaWCeVNBtXPRY2YIdrgcsL2+vd5F07FxgihHUw==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
+
 "@fortawesome/fontawesome-common-types@6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"
@@ -9473,10 +9485,10 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue-tippy@^6.0.0-alpha.52:
-  version "6.0.0-alpha.60"
-  resolved "https://registry.yarnpkg.com/vue-tippy/-/vue-tippy-6.0.0-alpha.60.tgz#8137eb6ae36cf9c1755d15b938b6f20f4baf812f"
-  integrity sha512-tORQ7/jOfrkhsJDBpgi9v7JERIen2GulkZekjNK9hSFWdwQFxxtnCjbGdjATbgxcyG3eckvjlWoh0bCk9ZoEhA==
+vue-tippy@^6.0.0-alpha.62:
+  version "6.0.0-alpha.62"
+  resolved "https://registry.yarnpkg.com/vue-tippy/-/vue-tippy-6.0.0-alpha.62.tgz#1bd6d70ee8b07fb11cb816d92b6cc72db61834b1"
+  integrity sha512-Q+Dn7D3tJq0w9HSWbxAexZ9LaP96Kg0dK8ridBKNsgcRBtYHJcaP4TqA/qSl5HbEv7bcD7dqQ4Q9zndMKkE4mw==
   dependencies:
     tippy.js "^6.3.7"
 


### PR DESCRIPTION
closes monarch-initiative/monarch-api#96  (positioning burden lifted, accessibility burden not. no acceptable libraries found at this time to lift that burden.)

- rename v-tippy to v-tooltip. better clarity, library-agnostic, positions us better to switch off of tippy in future
- install floating ui for pure positioning of dropdowns/popups/etc. this is already a part of tippy, but they don't expose just the positioning engine without any styling. when floating ui is more mature and has associated libraries for accessible tooltips, hopefully we will switch tippy to floating-ui too.
- make little red notification dot into generic class
- use floating ui to position select component dropdowns, and update components a bit
- make useFloating composable to allow components to be positioned with floating ui
- get rid of kebabify util func, no longer needed due to some component refactors
- add testbed to axe test, and open up each select component to check for accessibility issues with dropdown