### PR TITLE
Breadcrumbs section

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   /** don't lint certain files */
-  ignorePatterns: ["mockServiceWorker.js"],
+  ignorePatterns: [],
 
   /** is this needed? */
   overrides: [

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 /tests/e2e/screenshots/
 /cypress
 
+mockServiceWorker.js
+
 # local env files
 .env.local
 .env.*.local

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-mockServiceWorker.js

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Hosting at a default GitHub Pages url like monarch-initiative.github.io/monarch-
   - `/assets` - Static resources like images.
   - `/components` - Reusable building blocks of UI.
   - `/global` - Components, directives, styles, and other "global" resources that always -- whether running the app normally or setting up and mounting a test -- need to be included in the Vue application instance.
+    Also includes global variables and associated functions.
   - `/router` - See [Vue router](https://router.vuejs.org/).
   - `/store` - See [Vuex](https://vuex.vuejs.org/) (similar to Redux).
     Most useful for managing global and complex state.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit /unit",
     "test:e2e": "vue-cli-service test:e2e --browser=chrome --headless --e2e",
-    "lint": "vue-cli-service lint && prettier --write \"**/*.{scss,js,ts,json,vue,svg,yaml}\" --no-error-on-unmatched-pattern",
+    "lint": "vue-cli-service lint && prettier --ignore-path .gitignore --write \"**/*.{scss,js,ts,json,vue,svg,yaml}\" --no-error-on-unmatched-pattern",
     "fresh": "yarn cache clean && rm -rf node_modules yarn.lock && yarn install",
     "test": "yarn test:lint && yarn test:unit && yarn test:e2e && yarn test:axe",
     "test:axe": "vue-cli-service test:unit /axe",
     "test:gui": "vue-cli-service test:e2e --browser=chrome --e2e",
-    "test:lint": "vue-cli-service lint --no-fix && prettier --check \"**/*.{scss,js,ts,json,vue,svg,yaml}\" --no-error-on-unmatched-pattern"
+    "test:lint": "vue-cli-service lint --no-fix && prettier --ignore-path .gitignore --check \"**/*.{scss,js,ts,json,vue,svg,yaml}\" --no-error-on-unmatched-pattern"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.0.0",

--- a/public/404.html
+++ b/public/404.html
@@ -18,14 +18,6 @@
       const { origin, pathname, search, hash } = window.location;
       const { state } = window.history;
 
-      /** only keep state added by app, as to not interfere with built-in browser nav */
-      delete state.back;
-      delete state.current;
-      delete state.forward;
-      delete state.position;
-      delete state.replaced;
-      delete state.scroll;
-
       /** set redirect and state */
       window.sessionStorage.redirect = pathname + search + hash;
       window.sessionStorage.redirectState = JSON.stringify(state);

--- a/public/404.html
+++ b/public/404.html
@@ -11,15 +11,15 @@
        */
 
       /** turn on "preserve log" in chrome dev tools to still see this after nav */
-      console.info(
-        `Redirecting from location ${window.location}, with history ${window.history}`
-      );
+      console.info("Redirecting from:", window.location);
+      console.info("With history:", window.history);
 
       /** set redirect and state */
       const { origin, pathname, search, hash } = window.location;
       const { state } = window.history;
       window.sessionStorage.redirect = pathname + search + hash;
-      window.history.replaceState(state, null, "/");
+      window.sessionStorage.redirectState = state;
+      window.location = "/";
     </script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -18,7 +18,7 @@
       const { origin, pathname, search, hash } = window.location;
       const { state } = window.history;
       window.sessionStorage.redirect = pathname + search + hash;
-      window.sessionStorage.redirectState = state;
+      window.sessionStorage.redirectState = JSON.stringify(state);
       window.location = "/";
     </script>
   </body>

--- a/public/404.html
+++ b/public/404.html
@@ -14,9 +14,19 @@
       console.info("Redirecting from:", window.location);
       console.info("With state:", window.history.state);
 
-      /** set redirect and state */
+      /** get redirect and state */
       const { origin, pathname, search, hash } = window.location;
       const { state } = window.history;
+
+      /** only keep state added by app, as to not interfere with built-in browser nav */
+      delete state.back;
+      delete state.current;
+      delete state.forward;
+      delete state.position;
+      delete state.replaced;
+      delete state.scroll;
+
+      /** set redirect and state */
       window.sessionStorage.redirect = pathname + search + hash;
       window.sessionStorage.redirectState = JSON.stringify(state);
       window.location = "/";

--- a/public/404.html
+++ b/public/404.html
@@ -12,7 +12,7 @@
 
       /** turn on "preserve log" in chrome dev tools to still see this after nav */
       console.info("Redirecting from:", window.location);
-      console.info("With history:", window.history);
+      console.info("With state:", window.history.state);
 
       /** set redirect and state */
       const { origin, pathname, search, hash } = window.location;

--- a/public/404.html
+++ b/public/404.html
@@ -3,14 +3,23 @@
     <script type="text/javascript">
       /** 404 redirect page */
 
-      /** only needed when navigating directly (from a fresh tab) to a sub-page when hosted on GitHub Pages, Netlify, etc. when navigating within the app, or on local dev server, vue-router handles everything. */
+      /**
+       * only needed when app is hosted on GitHub Pages, Netlify, etc. and when
+       * navigating directly (from a fresh tab) to a non-root page. when
+       * navigating within the app, or on local dev server, vue-router handles
+       * everything.
+       */
 
       /** turn on "preserve log" in chrome dev tools to still see this after nav */
-      console.info(`Redirecting from ${location}`);
+      console.info(
+        `Redirecting from location ${window.location}, with history ${window.history}`
+      );
 
-      const { origin, pathname, search, hash } = location;
+      /** set redirect and state */
+      const { origin, pathname, search, hash } = window.location;
+      const { state } = window.history;
       window.sessionStorage.redirect = pathname + search + hash;
-      location.replace("/");
+      window.history.replaceState(state, null, "/");
     </script>
   </body>
 </html>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -102,7 +102,7 @@ const name = "monarch-cache";
 /** start cache */
 const initCache = async () => {
   /** start fresh each session (as if using sessionStorage) */
-  if (process.env.NODE_ENV !== "development") await window.caches.delete(name);
+  await window.caches.delete(name);
   /** set cache interface */
   cache = await window.caches.open(name);
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -101,6 +101,7 @@ const name = "monarch-cache";
 
 /** start cache */
 const initCache = async () => {
+  console.log("init cache");
   /** start fresh each session (as if using sessionStorage) */
   await window.caches.delete(name);
   /** set cache interface */

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -101,7 +101,6 @@ const name = "monarch-cache";
 
 /** start cache */
 const initCache = async () => {
-  console.log("init cache");
   /** start fresh each session (as if using sessionStorage) */
   await window.caches.delete(name);
   /** set cache interface */

--- a/src/api/phenotype-explorer.ts
+++ b/src/api/phenotype-explorer.ts
@@ -1,6 +1,7 @@
 import { biolink, request } from ".";
 import { getSearchResults } from "./node-search";
 import { Options, OptionsFunc } from "@/components/AppSelectTags.d";
+import { stringify } from "@/util/object";
 
 /** search individual phenotypes or gene/disease phenotypes */
 export const getPhenotypes = async (search = ""): ReturnType<OptionsFunc> => {
@@ -112,7 +113,7 @@ export const compareSetToSet = async (
   const options = {
     method: "POST",
     headers,
-    body: JSON.stringify(body),
+    body: stringify(body),
   };
 
   /** make query */

--- a/src/components/AppBreadcrumbsLink.vue
+++ b/src/components/AppBreadcrumbsLink.vue
@@ -1,0 +1,22 @@
+<!--
+  link that adds breadcrumb to breadcrumb list when clicked
+-->
+
+<template>
+  <AppLink :to="to" :state="{ breadcrumbs: [...breadcrumbs, breadcrumb] }">
+    <slot />
+  </AppLink>
+</template>
+
+<script setup lang="ts">
+import { breadcrumbs } from "@/global/breadcrumbs";
+
+interface Props {
+  /** location to link to */
+  to: string;
+  /** "current" breadcrumb to add list */
+  breadcrumb: Record<string, unknown>;
+}
+
+defineProps<Props>();
+</script>

--- a/src/components/AppFlex.vue
+++ b/src/components/AppFlex.vue
@@ -7,6 +7,7 @@
 <template>
   <div
     class="flex"
+    :data-flow="flow"
     :data-direction="direction"
     :data-gap="gap"
     :style="{ justifyContent, alignItems }"
@@ -17,7 +18,6 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-
 /** map nice human align names to css flex align names */
 const alignMap = {
   left: "flex-start",
@@ -29,6 +29,8 @@ const alignMap = {
 };
 
 interface Props {
+  /** flex display (whether container takes up full width) */
+  flow?: "inline" | "block";
   /** horizontal or vertical */
   direction?: "row" | "col";
   /** spacing between items */
@@ -40,6 +42,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  flow: "block",
   direction: "row",
   gap: "medium",
   hAlign: "center",
@@ -57,8 +60,14 @@ const alignItems = computed(() =>
 
 <style lang="scss" scoped>
 .flex {
-  display: flex;
-  width: 100%;
+  &[data-flow="block"] {
+    display: flex;
+    width: 100%;
+  }
+
+  &[data-flow="inline"] {
+    display: inline-flex;
+  }
 
   &[data-direction="row"] {
     flex-wrap: wrap;
@@ -71,15 +80,19 @@ const alignItems = computed(() =>
   &[data-gap="none"] {
     gap: 0;
   }
+
   &[data-gap="tiny"] {
     gap: 5px;
   }
+
   &[data-gap="small"] {
     gap: 10px;
   }
+
   &[data-gap="medium"] {
     gap: 20px;
   }
+
   &[data-gap="big"] {
     gap: 40px;
   }

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -22,7 +22,11 @@
 
   <router-link
     v-else
-    :to="to.startsWith('#') ? { ...$route, hash: to } : to"
+    :to="{
+      path: to.startsWith('#') ? '' : to,
+      hash: to.startsWith('#') ? to : undefined,
+      state,
+    }"
     :replace="to.startsWith('#')"
   >
     <!-- use vue router component for relative urls -->
@@ -33,15 +37,24 @@
 <script setup lang="ts">
 import { computed, useSlots } from "vue";
 import { isExternal, isAbsolute } from "@/util/url";
+import { HistoryState } from "vue-router";
 
 interface Props {
   /** location to link to */
   to: string;
+  /**
+   * state data to attach on navigation
+   * https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
+   */
+  state?: HistoryState;
   /** whether to forcibly forgo external icon when link is external */
   noIcon?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), { noIcon: false });
+const props = withDefaults(defineProps<Props>(), {
+  noIcon: false,
+  state: undefined,
+});
 
 const slots = useSlots();
 

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -25,7 +25,7 @@
     :to="{
       path: to.startsWith('#') ? '' : to,
       hash: to.startsWith('#') ? to : undefined,
-      state,
+      state: mapValues(state, JSON.stringify),
     }"
     :replace="to.startsWith('#')"
   >
@@ -36,17 +36,17 @@
 
 <script setup lang="ts">
 import { computed, useSlots } from "vue";
+import { mapValues } from "lodash";
 import { isExternal, isAbsolute } from "@/util/url";
-import { HistoryState } from "vue-router";
 
 interface Props {
   /** location to link to */
   to: string;
   /**
-   * state data to attach on navigation
+   * state data to attach on navigation. object/array values get stringified.
    * https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
    */
-  state?: HistoryState;
+  state?: Record<string, unknown>;
   /** whether to forcibly forgo external icon when link is external */
   noIcon?: boolean;
 }

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -25,7 +25,7 @@
     :to="{
       path: to.startsWith('#') ? '' : to,
       hash: to.startsWith('#') ? to : undefined,
-      state: mapValues(state, JSON.stringify),
+      state: mapValues(state, stringify),
     }"
     :replace="to.startsWith('#')"
   >
@@ -38,6 +38,7 @@
 import { computed, useSlots } from "vue";
 import { mapValues } from "lodash";
 import { isExternal, isAbsolute } from "@/util/url";
+import { stringify } from "@/util/object";
 
 interface Props {
   /** location to link to */

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -25,7 +25,7 @@
     :to="{
       path: to.startsWith('#') ? '' : to,
       hash: to.startsWith('#') ? to : undefined,
-      state: mapValues(state, stringify),
+      state: mapValues(state, (value) => stringify(value)),
     }"
     :replace="to.startsWith('#')"
   >

--- a/src/components/AppSelectSingle.vue
+++ b/src/components/AppSelectSingle.vue
@@ -212,7 +212,6 @@ watch(highlighted, () =>
 );
 
 /** auto-select first option as fallback */
-/*
 watch(
   () => props.options,
   () => {
@@ -220,7 +219,6 @@ watch(
   },
   { immediate: true }
 );
-*/
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/TheTableOfContents.vue
+++ b/src/components/TheTableOfContents.vue
@@ -1,6 +1,7 @@
 <template>
   <AppFlex
     ref="toc"
+    flow="inline"
     direction="col"
     gap="none"
     h-align="stretch"
@@ -168,7 +169,6 @@ useMutationObserver(
 .toc {
   position: fixed;
   top: 0;
-  width: unset;
   background: $white;
   box-shadow: $shadow;
   z-index: 10;

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -9,3 +9,13 @@ interface Breadcrumb {
 
 /** breadcrumbs object for breadcrumbs section on node page */
 export const breadcrumbs = ref<Array<Breadcrumb>>([]);
+
+/** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
+export const updateBreadcrumbs = () => {
+  try {
+    breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
+  } catch (error) {
+    console.warn("Bad breadcrumbs state");
+    breadcrumbs.value = [];
+  }
+};

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -1,8 +1,9 @@
 import { ref } from "vue";
+import { Node } from "@/api/node-lookup";
 import { Association } from "@/api/node-associations";
 
 interface Breadcrumb {
-  subject: Association["subject"];
+  node: Node;
   relation: Association["relation"];
 }
 

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -1,6 +1,7 @@
 import { ref } from "vue";
 import { Node } from "@/api/node-lookup";
 import { Association } from "@/api/node-associations";
+import { parse } from "@/util/object";
 
 interface Breadcrumb {
   node: Node;
@@ -11,11 +12,5 @@ interface Breadcrumb {
 export const breadcrumbs = ref<Array<Breadcrumb>>([]);
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
-export const updateBreadcrumbs = () => {
-  try {
-    breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
-  } catch (error) {
-    console.warn("Bad breadcrumbs state", window.history.state.breadcrumbs);
-    breadcrumbs.value = [];
-  }
-};
+export const updateBreadcrumbs = () =>
+  (breadcrumbs.value = parse(window.history.state.breadcrumbs, []));

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -12,7 +12,6 @@ export const breadcrumbs = ref<Array<Breadcrumb>>([]);
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
 export const updateBreadcrumbs = () => {
-  console.info(window.history);
   try {
     breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
   } catch (error) {

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -12,10 +12,11 @@ export const breadcrumbs = ref<Array<Breadcrumb>>([]);
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
 export const updateBreadcrumbs = () => {
+  console.info(window.history);
   try {
     breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
   } catch (error) {
-    console.warn("Bad breadcrumbs state");
+    console.warn("Bad breadcrumbs state", window.history.state.breadcrumbs);
     breadcrumbs.value = [];
   }
 };

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -1,0 +1,10 @@
+import { ref } from "vue";
+import { Association } from "@/api/node-associations";
+
+interface Breadcrumb {
+  subject: Association["subject"];
+  relation: Association["relation"];
+}
+
+/** breadcrumbs object for breadcrumbs section on node page */
+export const breadcrumbs = ref<Array<Breadcrumb>>([]);

--- a/src/global/breadcrumbs.ts
+++ b/src/global/breadcrumbs.ts
@@ -13,4 +13,4 @@ export const breadcrumbs = ref<Array<Breadcrumb>>([]);
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
 export const updateBreadcrumbs = () =>
-  (breadcrumbs.value = parse(window.history.state.breadcrumbs, []));
+  (breadcrumbs.value = parse(window.history.state?.breadcrumbs, []));

--- a/src/global/styles.scss
+++ b/src/global/styles.scss
@@ -140,7 +140,8 @@ code {
 }
 
 strong {
-  font-weight: 500;
+  font-weight: 600;
+  margin: 0 2px;
 }
 
 /** notification dot */

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,9 @@ import plugins from "@/global/plugins";
 import { handlers } from "../tests/fixtures";
 import "@/global/meta";
 
+/** log env variables for debugging */
+console.info(process.env);
+
 /** create main app object */
 let app = createApp(App);
 
@@ -18,7 +21,8 @@ for (const [name, Component] of Object.entries(components))
 
 (async () => {
   /** mock api for local development */
-  if (process.env.NODE_ENV === "development") {
+
+  if (process.env.NODE_ENV === "development" && process.env.CI !== "true") {
     const { setupWorker } = await import("msw");
     await setupWorker(...handlers).start();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { createApp } from "vue";
-import { setupWorker } from "msw";
 import "wicg-inert";
 import App from "@/App.vue";
 import components from "@/global/components";
@@ -17,16 +16,13 @@ for (const [plugin, options] of plugins) app = app.use(plugin, options);
 for (const [name, Component] of Object.entries(components))
   app = app.component(name, Component);
 
-/** render app */
-const startApp = () => app.mount("#app");
+(async () => {
+  /** mock api for local development */
+  if (process.env.NODE_ENV === "development") {
+    const { setupWorker } = await import("msw");
+    await setupWorker(...handlers).start();
+  }
 
-/** mock api for local development */
-const mock = false;
-// const mock = process.env.NODE_ENV === "development";
-
-/** start app */
-if (mock)
-  setupWorker(...handlers)
-    .start()
-    .then(startApp);
-else startApp();
+  /** start app */
+  app.mount("#app");
+})();

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,7 @@ for (const [name, Component] of Object.entries(components))
 
 (async () => {
   /** mock api for local development */
-
-  if (process.env.NODE_ENV === "development" && process.env.CI !== "true") {
+  if (process.env.NODE_ENV === "development") {
     const { setupWorker } = await import("msw");
     await setupWorker(...handlers).start();
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,6 @@ import {
   RouterScrollBehavior,
   NavigationGuard,
 } from "vue-router";
-import { clone } from "lodash";
 import { hideAll } from "tippy.js";
 import PageHome from "@/views/PageHome.vue";
 import PageExplore from "@/views/explore/PageExplore.vue";
@@ -214,7 +213,7 @@ export const scrollToHash = () =>
   scrollToElement(document?.getElementById(window.location.hash.slice(1)));
 
 /** navigation history object */
-const history = createWebHistory(process.env.BASE_URL);
+export const history = createWebHistory(process.env.BASE_URL);
 
 /** router object */
 const router = createRouter({
@@ -229,22 +228,3 @@ router.beforeEach(() => {
 });
 
 export default router;
-
-/**
- * dirty way to allow passing arbitrary data with router.push. will no longer be
- * needed once this vue-router RFC is implemented:
- * https://github.com/vuejs/rfcs/discussions/400
- */
-let routeData: unknown = null;
-
-/** attach data to be consumed after route change */
-export const setData = (data: unknown): void => {
-  routeData = data;
-};
-
-/** consume data set before route change */
-export const getData = (): unknown => {
-  const copy = clone(routeData);
-  routeData = null; /** reset after data consumed once */
-  return copy;
-};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -34,9 +34,16 @@ export const routes: Array<RouteRecordRaw> = [
     beforeEnter: (async () => {
       /** look for redirect in session storage (saved from public/404.html page) */
       const redirect = window.sessionStorage.redirect;
+      const redirectState = window.sessionStorage.redirectState;
+      window.sessionStorage.removeItem("redirect");
+      window.sessionStorage.removeItem("redirectState");
+
       if (redirect) {
-        console.info(`Redirecting to ${redirect}`);
-        delete window.sessionStorage.redirect;
+        console.info("Redirecting to:", redirect);
+        if (redirectState) {
+          console.info("With state:", redirectState);
+          window.history.replaceState(redirectState, "");
+        }
         return redirect;
       }
     }) as NavigationGuard,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import {
   RouteRecordRaw,
   RouterScrollBehavior,
   NavigationGuard,
+  RouteLocationRaw,
 } from "vue-router";
 import { hideAll } from "tippy.js";
 import PageHome from "@/views/PageHome.vue";
@@ -38,15 +39,11 @@ export const routes: Array<RouteRecordRaw> = [
       const redirectState = parse(window.sessionStorage.redirectState);
       window.sessionStorage.removeItem("redirect");
       window.sessionStorage.removeItem("redirectState");
+      console.info("Redirecting to:", redirect);
+      console.info("With state:", redirectState);
 
-      if (redirect) {
-        console.info("Redirecting to:", redirect);
-        if (redirectState) {
-          console.info("With state:", redirectState);
-          window.history.replaceState(redirectState, "");
-        }
-        return redirect;
-      }
+      if (redirect)
+        return { path: redirect, state: redirectState } as RouteLocationRaw;
     }) as NavigationGuard,
   },
   {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,7 @@ import PageNode from "@/views/node/PageNode.vue";
 import PageTestbed from "@/views/PageTestbed.vue";
 import { sleep } from "@/util/debug";
 import { lookupNode } from "@/api/node-lookup";
+import { parse } from "@/util/object";
 import descriptions from "@/router/descriptions.json";
 
 /** list of routes and corresponding components. */
@@ -34,7 +35,7 @@ export const routes: Array<RouteRecordRaw> = [
     beforeEnter: (async () => {
       /** look for redirect in session storage (saved from public/404.html page) */
       const redirect = window.sessionStorage.redirect;
-      const redirectState = window.sessionStorage.redirectState;
+      const redirectState = parse(window.sessionStorage.redirectState);
       window.sessionStorage.removeItem("redirect");
       window.sessionStorage.removeItem("redirectState");
 

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -1,6 +1,8 @@
+import { stringify } from "@/util/object";
+
 /** download json data as json file */
 export const downloadJson = (data = {}, filename = "data"): void => {
-  const blob = new Blob([JSON.stringify(data, null, 2)], {
+  const blob = new Blob([stringify(data, 2)], {
     type: "application/json",
   });
   const url = window.URL.createObjectURL(blob);

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -43,3 +43,23 @@ export const renameKey = (
     delete object[oldKey];
   }
 };
+
+/** safe json stringify */
+export const stringify = (value: unknown, space = 0) => {
+  try {
+    return JSON.stringify(value, null, space);
+  } catch (error) {
+    console.warn("Invalid JSON stringify", value);
+    return "";
+  }
+};
+
+/** safe json parse */
+export const parse = (value: string, defaultValue: unknown = null) => {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn("Invalid JSON parse", value);
+    return defaultValue;
+  }
+};

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -47,9 +47,12 @@ export const renameKey = (
 /** safe json stringify */
 export const stringify = (value: unknown, space = 0) => {
   try {
-    return JSON.stringify(value, null, space);
+    if (!value) return "";
+    else return JSON.stringify(value, null, space);
   } catch (error) {
-    console.warn("Invalid JSON stringify", value);
+    console.warn("Invalid JSON stringify");
+    console.info(value);
+    console.info(error);
     return "";
   }
 };
@@ -57,9 +60,12 @@ export const stringify = (value: unknown, space = 0) => {
 /** safe json parse */
 export const parse = (value: string, defaultValue: unknown = null) => {
   try {
-    return JSON.parse(value);
+    if (!value) return defaultValue;
+    else return JSON.parse(value);
   } catch (error) {
-    console.warn("Invalid JSON parse", value);
+    console.warn("Invalid JSON parse");
+    console.info(value);
+    console.info(error);
     return defaultValue;
   }
 };

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -184,7 +184,8 @@ async function getAutocomplete(search: string): Promise<AutocompleteOptions> {
     .map((search) => ({
       name: search,
       icon: "clock-rotate-left",
-      tooltip: "One of your recent searches. Shift + Del to remove.",
+      tooltip:
+        "One of your recent node searches/visits. Shift + Del to remove.",
     }));
 
   /** most popular searches */
@@ -201,7 +202,8 @@ async function getAutocomplete(search: string): Promise<AutocompleteOptions> {
     .map(({ search }) => ({
       name: search,
       icon: "person-running",
-      tooltip: "One of your frequent searches. Shift + Del to remove.",
+      tooltip:
+        "One of your frequent node searches/visits. Shift + Del to remove.",
     }));
 
   /** example searches */

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -184,12 +184,12 @@ async function getAutocomplete(search: string): Promise<AutocompleteOptions> {
     .map((search) => ({
       name: search,
       icon: "clock-rotate-left",
-      tooltip: "Recent search. Shift + Del to remove.",
+      tooltip: "One of your recent searches. Shift + Del to remove.",
     }));
 
   /** most popular searches */
   const popular = sortBy(
-    Object.entries(groupBy(history)).map(([search, matches]) => ({
+    Object.entries(groupBy(history.value)).map(([search, matches]) => ({
       search,
       count: matches.length,
     })),
@@ -201,7 +201,7 @@ async function getAutocomplete(search: string): Promise<AutocompleteOptions> {
     .map(({ search }) => ({
       name: search,
       icon: "person-running",
-      tooltip: "Frequent search. Shift + Del to remove.",
+      tooltip: "One of your frequent searches. Shift + Del to remove.",
     }));
 
   /** example searches */

--- a/src/views/explore/NodeSearch.vue
+++ b/src/views/explore/NodeSearch.vue
@@ -188,14 +188,17 @@ async function getAutocomplete(search: string): Promise<AutocompleteOptions> {
     }));
 
   /** most popular searches */
-  const popular = uniq(
-    sortBy(Object.values(groupBy(history.value)), "length").map(
-      (array) => array[0]
-    )
+  const popular = sortBy(
+    Object.entries(groupBy(history)).map(([search, matches]) => ({
+      search,
+      count: matches.length,
+    })),
+    "count"
   )
+    .filter(({ count }) => count >= 3)
     .reverse()
     .slice(0, top)
-    .map((search) => ({
+    .map(({ search }) => ({
       name: search,
       icon: "person-running",
       tooltip: "Frequent search. Shift + Del to remove.",

--- a/src/views/explore/PhenotypeExplorer.vue
+++ b/src/views/explore/PhenotypeExplorer.vue
@@ -314,8 +314,8 @@ watch([aPhenotypes, bMode, bTaxon, bPhenotypes], clearResults, { deep: true });
 
 /** fill in phenotype ids from text annotator */
 onMounted(() => {
-  const phenotypes = window.history.state.phenotypes as Options;
-  if (phenotypes) {
+  if (window.history.state.phenotypes) {
+    const phenotypes = JSON.parse(window.history.state.phenotypes) as Options;
     aPhenotypes.value = phenotypes;
     aGeneratedFrom.value = {
       option: { id: "text annotator" },

--- a/src/views/explore/PhenotypeExplorer.vue
+++ b/src/views/explore/PhenotypeExplorer.vue
@@ -146,6 +146,7 @@ import { Option, Options } from "@/components/AppSelectTags";
 import { snackbar } from "@/components/TheSnackbar";
 import { mountPhenogrid } from "@/api/phenogrid";
 import { useQuery } from "@/util/composables";
+import { parse } from "@/util/object";
 
 /** common tooltip explaining how to use multi-select component */
 const multiTooltip = `In this box, you can select phenotypes in 3 ways:<br>
@@ -315,7 +316,7 @@ watch([aPhenotypes, bMode, bTaxon, bPhenotypes], clearResults, { deep: true });
 /** fill in phenotype ids from text annotator */
 onMounted(() => {
   if (window.history.state.phenotypes) {
-    const phenotypes = JSON.parse(window.history.state.phenotypes) as Options;
+    const phenotypes = parse(window.history.state.phenotypes, []) as Options;
     aPhenotypes.value = phenotypes;
     aGeneratedFrom.value = {
       option: { id: "text annotator" },

--- a/src/views/explore/PhenotypeExplorer.vue
+++ b/src/views/explore/PhenotypeExplorer.vue
@@ -133,7 +133,6 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from "vue";
 import { startCase, kebabCase, isEqual } from "lodash";
-import { getData } from "@/router";
 import AppSelectTags from "@/components/AppSelectTags.vue";
 import AppSelectSingle from "@/components/AppSelectSingle.vue";
 import AppRing from "@/components/AppRing.vue";
@@ -315,7 +314,7 @@ watch([aPhenotypes, bMode, bTaxon, bPhenotypes], clearResults, { deep: true });
 
 /** fill in phenotype ids from text annotator */
 onMounted(() => {
-  const phenotypes = getData() as Options;
+  const phenotypes = window.history.state.phenotypes as Options;
   if (phenotypes) {
     aPhenotypes.value = phenotypes;
     aGeneratedFrom.value = {

--- a/src/views/explore/TextAnnotator.vue
+++ b/src/views/explore/TextAnnotator.vue
@@ -64,9 +64,10 @@
         v-tooltip="
           'Send any annotations above that are phenotypes to Phenotype Explorer'
         "
+        to="#phenotype-explorer"
+        :state="{ phenotypes: getPhenotypes() }"
         text="Analyze Phenotypes"
         icon="bars-progress"
-        @click="analyze"
       />
     </AppFlex>
   </AppSection>
@@ -82,12 +83,8 @@ import AppStatus from "@/components/AppStatus.vue";
 import example from "./text-annotator.json";
 import { annotateText } from "@/api/text-annotator";
 import { downloadJson } from "@/util/download";
-import { useRouter } from "vue-router";
 import { appendToBody } from "@/global/tooltip";
 import { useQuery } from "@/util/composables";
-
-/** route info */
-const router = useRouter();
 
 /** text content */
 const content = useLocalStorage("annotations-content", "");
@@ -132,8 +129,8 @@ function download() {
   );
 }
 
-/** send phenotype annotations to phenotype explorer to analyze */
-function analyze() {
+/** get phenotype annotations to send to phenotype explorer */
+function getPhenotypes() {
   /** gather annotations that are phenotypes */
   const phenotypes = [];
   for (const { tokens } of annotations.value)
@@ -141,10 +138,7 @@ function analyze() {
       if (id.startsWith("HP:")) phenotypes.push({ id, name });
 
   /** de-duplicate, and send them to phenotype explorer component via router */
-  router.push({
-    hash: "#phenotype-explorer",
-    state: { phenotypes: uniqBy(phenotypes, "id") },
-  });
+  return uniqBy(phenotypes, "id");
 }
 
 /** run annotations on mount if content loaded from storage */

--- a/src/views/explore/TextAnnotator.vue
+++ b/src/views/explore/TextAnnotator.vue
@@ -82,7 +82,6 @@ import AppStatus from "@/components/AppStatus.vue";
 import example from "./text-annotator.json";
 import { annotateText } from "@/api/text-annotator";
 import { downloadJson } from "@/util/download";
-import { setData } from "@/router";
 import { useRouter } from "vue-router";
 import { appendToBody } from "@/global/tooltip";
 import { useQuery } from "@/util/composables";
@@ -142,8 +141,10 @@ function analyze() {
       if (id.startsWith("HP:")) phenotypes.push({ id, name });
 
   /** de-duplicate, and send them to phenotype explorer component via router */
-  setData(uniqBy(phenotypes, "id"));
-  router.push({ hash: "#phenotype-explorer" });
+  router.push({
+    hash: "#phenotype-explorer",
+    state: { phenotypes: uniqBy(phenotypes, "id") },
+  });
 }
 
 /** run annotations on mount if content loaded from storage */

--- a/src/views/node/AssociationsSummary.vue
+++ b/src/views/node/AssociationsSummary.vue
@@ -47,7 +47,7 @@
           <AppBreadcrumbsLink
             :to="`/${association.object.category}/${association.object.id}`"
             :breadcrumb="{
-              subject: association.subject,
+              node,
               relation: association.relation,
             }"
             >{{ association.object.name }}</AppBreadcrumbsLink

--- a/src/views/node/AssociationsSummary.vue
+++ b/src/views/node/AssociationsSummary.vue
@@ -46,6 +46,10 @@
           />
           <AppLink
             :to="`/${association.object.category}/${association.object.id}`"
+            :state="{
+              subject: association.subject,
+              relation: association.relation,
+            }"
             >{{ association.object.name }}</AppLink
           >
         </AppFlex>

--- a/src/views/node/AssociationsSummary.vue
+++ b/src/views/node/AssociationsSummary.vue
@@ -44,13 +44,13 @@
                 : 'arrow-right-long'
             "
           />
-          <AppLink
+          <AppBreadcrumbsLink
             :to="`/${association.object.category}/${association.object.id}`"
-            :state="{
+            :breadcrumb="{
               subject: association.subject,
               relation: association.relation,
             }"
-            >{{ association.object.name }}</AppLink
+            >{{ association.object.name }}</AppBreadcrumbsLink
           >
         </AppFlex>
 
@@ -90,6 +90,7 @@
 <script setup lang="ts">
 import { watch, onMounted } from "vue";
 import AppStatus from "@/components/AppStatus.vue";
+import AppBreadcrumbsLink from "@/components/AppBreadcrumbsLink.vue";
 import { Node } from "@/api/node-lookup";
 import { getTopAssociations, Association } from "@/api/node-associations";
 import { useQuery } from "@/util/composables";

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -51,11 +51,11 @@
 
     <!-- "object" (what current node has an association with) -->
     <template #object="{ cell, row }">
-      <AppLink
+      <AppBreadcrumbsLink
         class="truncate"
         :to="`/${cell.category}/${cell.id}`"
-        :state="{ subject: row.subject, relation: row.relation }"
-        >{{ cell.name }}</AppLink
+        :breadcrumb="{ subject: row.subject, relation: row.relation }"
+        >{{ cell.name }}</AppBreadcrumbsLink
       >
     </template>
 
@@ -111,6 +111,7 @@ import { startCase } from "lodash";
 import AppTable from "@/components/AppTable.vue";
 import AppStatus from "@/components/AppStatus.vue";
 import { Col, Cols, Sort } from "@/components/AppTable";
+import AppBreadcrumbsLink from "@/components/AppBreadcrumbsLink.vue";
 import { Node } from "@/api/node-lookup";
 import { getTabulatedAssociations, Association } from "@/api/node-associations";
 import { downloadJson } from "@/util/download";

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -54,7 +54,7 @@
       <AppBreadcrumbsLink
         class="truncate"
         :to="`/${cell.category}/${cell.id}`"
-        :breadcrumb="{ subject: row.subject, relation: row.relation }"
+        :breadcrumb="{ node, relation: row.relation }"
         >{{ cell.name }}</AppBreadcrumbsLink
       >
     </template>

--- a/src/views/node/AssociationsTable.vue
+++ b/src/views/node/AssociationsTable.vue
@@ -50,10 +50,13 @@
     </template>
 
     <!-- "object" (what current node has an association with) -->
-    <template #object="{ cell }">
-      <AppLink class="truncate" :to="`/${cell.category}/${cell.id}`">{{
-        cell.name
-      }}</AppLink>
+    <template #object="{ cell, row }">
+      <AppLink
+        class="truncate"
+        :to="`/${cell.category}/${cell.id}`"
+        :state="{ subject: row.subject, relation: row.relation }"
+        >{{ cell.name }}</AppLink
+      >
     </template>
 
     <!-- button to show evidence -->

--- a/src/views/node/EvidenceViewer.vue
+++ b/src/views/node/EvidenceViewer.vue
@@ -132,10 +132,13 @@
         </template>
 
         <!-- "object" -->
-        <template #object="{ cell }">
-          <AppLink class="truncate" :to="`/${cell.category}/${cell.id}`">{{
-            cell.name
-          }}</AppLink>
+        <template #object="{ cell, row }">
+          <AppLink
+            class="truncate"
+            :to="`/${cell.category}/${cell.id}`"
+            :state="{ subject: row.subject, relation: row.relation }"
+            >{{ cell.name }}</AppLink
+          >
         </template>
 
         <!-- evidence codes -->

--- a/src/views/node/EvidenceViewer.vue
+++ b/src/views/node/EvidenceViewer.vue
@@ -133,11 +133,11 @@
 
         <!-- "object" -->
         <template #object="{ cell, row }">
-          <AppLink
+          <AppBreadcrumbsLink
             class="truncate"
             :to="`/${cell.category}/${cell.id}`"
-            :state="{ subject: row.subject, relation: row.relation }"
-            >{{ cell.name }}</AppLink
+            :breadcrumb="{ subject: row.subject, relation: row.relation }"
+            >{{ cell.name }}</AppBreadcrumbsLink
           >
         </template>
 
@@ -216,6 +216,7 @@ import AppDetails from "@/components/AppDetails.vue";
 import AppDetail from "@/components/AppDetail.vue";
 import AppTable from "@/components/AppTable.vue";
 import AppStatus from "@/components/AppStatus.vue";
+import AppBreadcrumbsLink from "@/components/AppBreadcrumbsLink.vue";
 import { Node } from "@/api/node-lookup";
 import { scrollToElement } from "@/router";
 import { getAssociationEvidence } from "@/api/association-evidence";

--- a/src/views/node/EvidenceViewer.vue
+++ b/src/views/node/EvidenceViewer.vue
@@ -136,7 +136,7 @@
           <AppBreadcrumbsLink
             class="truncate"
             :to="`/${cell.category}/${cell.id}`"
-            :breadcrumb="{ subject: row.subject, relation: row.relation }"
+            :breadcrumb="{ node, relation: row.relation }"
             >{{ cell.name }}</AppBreadcrumbsLink
           >
         </template>

--- a/src/views/node/PageNode.vue
+++ b/src/views/node/PageNode.vue
@@ -64,7 +64,7 @@ const {
   isLoading,
   isError,
 } = useQuery(
-  async function getData() {
+  async function () {
     /** get node from route params */
     const { id = "", category = "" } = route.params;
 

--- a/src/views/node/PageNode.vue
+++ b/src/views/node/PageNode.vue
@@ -30,6 +30,7 @@
     <SectionDetails :node="node" />
     <SectionHierarchy :node="node" />
     <SectionAssociations :node="node" />
+    <SectionBreadcrumbs :node="node" />
 
     <Teleport to="body">
       <TheTableOfContents />
@@ -49,6 +50,7 @@ import SectionOverview from "./SectionOverview.vue";
 import SectionDetails from "./SectionDetails.vue";
 import SectionHierarchy from "./SectionHierarchy.vue";
 import SectionAssociations from "./SectionAssociations.vue";
+import SectionBreadcrumbs from "./SectionBreadcrumbs.vue";
 import { scrollToHash } from "@/router";
 import { useQuery } from "@/util/composables";
 import { appDescription, appTitle } from "@/global/meta";

--- a/src/views/node/SectionAssociations.vue
+++ b/src/views/node/SectionAssociations.vue
@@ -117,33 +117,27 @@ const categoryOptions = computed(
 watch(category, () => (association.value = undefined));
 
 /** update url from selected category */
-watch(category, (value, prev) =>
-  /**
-   * if category changed because it was set to default on page load, don't
-   * create new history entry
-   */
-  (prev ? router.push : router.replace)({
-    ...route,
-    query: { associations: category.value?.id },
-  })
+watch(
+  category,
+  (value, prev) => {
+    router.push({
+      ...route,
+      query: { associations: category.value?.id },
+      replace: !prev,
+    });
+  },
+  /** avoid extra triggering of watch functions */
+  { flush: "post" }
 );
 
 /** update selected category from url */
-function setCategoryFromUrl() {
-  if (route.query.associations)
-    category.value = categoryOptions.value.find(
-      (option) => option.id === route.query.associations
-    );
-}
-watch(() => route.query.associations, setCategoryFromUrl, { immediate: true });
-
-/** auto-select first category */
 watch(
-  categoryOptions,
+  () => route.query.associations,
   () => {
-    /** if no category selected, and no category about to be selected from url */
-    if (!category.value && !route.query.associations)
-      category.value = categoryOptions.value[0];
+    if (route.query.associations)
+      category.value = categoryOptions.value.find(
+        (option) => option.id === route.query.associations
+      );
   },
   { immediate: true }
 );

--- a/src/views/node/SectionBreadcrumbs.vue
+++ b/src/views/node/SectionBreadcrumbs.vue
@@ -60,7 +60,7 @@
 import { watch } from "vue";
 import { useRoute } from "vue-router";
 import { kebabCase, startCase } from "lodash";
-import { breadcrumbs } from "@/global/breadcrumbs";
+import { breadcrumbs, updateBreadcrumbs } from "@/global/breadcrumbs";
 import { Node } from "@/api/node-lookup";
 
 interface Props {
@@ -74,18 +74,7 @@ defineProps<Props>();
 const route = useRoute();
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
-watch(
-  () => route,
-  () => {
-    try {
-      breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
-    } catch (error) {
-      console.warn("Bad breadcrumbs state");
-      breadcrumbs.value = [];
-    }
-  },
-  { immediate: true, deep: true }
-);
+watch(() => route, updateBreadcrumbs, { immediate: true, deep: true });
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/node/SectionBreadcrumbs.vue
+++ b/src/views/node/SectionBreadcrumbs.vue
@@ -1,14 +1,88 @@
 <template>
-  <AppSection>
+  <AppSection v-if="breadcrumbs.length">
     <AppHeading icon="location-dot">Breadcrumbs</AppHeading>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </p>
+
+    <span
+      >How you got to <strong>{{ node.name }}</strong> through the Monarch
+      knowledge graph</span
+    >
+
+    <AppFlex>
+      <template v-for="(breadcrumb, index) of breadcrumbs" :key="index">
+        <!-- subject -->
+        <AppLink
+          class="truncate"
+          :to="`/${breadcrumb.subject.category}/${breadcrumb.subject.id}`"
+          >{{ breadcrumb.subject.name }}</AppLink
+        >
+
+        <!-- relation -->
+        <AppFlex flow="inline" gap="tiny">
+          <AppIcon
+            class="arrow"
+            :icon="
+              breadcrumb.relation.inverse
+                ? 'arrow-left-long'
+                : 'arrow-right-long'
+            "
+          />
+          <AppLink
+            class="truncate"
+            :to="breadcrumb.relation.iri"
+            :no-icon="true"
+            >{{ startCase(breadcrumb.relation.name) }}</AppLink
+          >
+          <AppIcon
+            class="arrow"
+            :icon="
+              breadcrumb.relation.inverse
+                ? 'arrow-left-long'
+                : 'arrow-right-long'
+            "
+          />
+        </AppFlex>
+      </template>
+
+      <!-- ending/current node -->
+      <strong>{{ node.name }}</strong>
+    </AppFlex>
   </AppSection>
 </template>
+
+<script setup lang="ts">
+import { watch } from "vue";
+import { useRoute } from "vue-router";
+import { startCase } from "lodash";
+import { breadcrumbs } from "@/global/breadcrumbs";
+import { Node } from "@/api/node-lookup";
+
+interface Props {
+  /** current node */
+  node: Node;
+}
+
+defineProps<Props>();
+
+/** route info */
+const route = useRoute();
+
+/** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
+watch(
+  () => route,
+  () => {
+    try {
+      breadcrumbs.value = JSON.parse(window.history.state.breadcrumbs);
+    } catch (error) {
+      console.warn("Bad breadcrumbs state");
+      breadcrumbs.value = [];
+    }
+  },
+  { immediate: true, deep: true }
+);
+</script>
+
+<style lang="scss" scoped>
+.arrow {
+  color: $gray;
+}
+</style>

--- a/src/views/node/SectionBreadcrumbs.vue
+++ b/src/views/node/SectionBreadcrumbs.vue
@@ -53,6 +53,15 @@
         <strong>{{ node.name }}</strong>
       </AppFlex>
     </AppFlex>
+
+    <!-- clear button -->
+    <AppButton
+      v-tooltip="'Clear breadcrumb history'"
+      icon="times"
+      text="Clear"
+      design="small"
+      @click="clear"
+    />
   </AppSection>
 </template>
 
@@ -75,6 +84,13 @@ const route = useRoute();
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
 watch(() => route, updateBreadcrumbs, { immediate: true, deep: true });
+
+/** clear breadcrumbs history */
+function clear() {
+  /** confirmation warning not necessary since back button should return to previous state */
+  window.history.pushState({}, "");
+  updateBreadcrumbs();
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/node/SectionBreadcrumbs.vue
+++ b/src/views/node/SectionBreadcrumbs.vue
@@ -9,16 +9,15 @@
 
     <AppFlex>
       <template v-for="(breadcrumb, index) of breadcrumbs" :key="index">
-        <!-- subject -->
+        <!-- node -->
         <AppFlex flow="inline" gap="small">
           <AppIcon
-            v-tooltip="startCase(breadcrumb.subject.category)"
-            :icon="`category-${kebabCase(breadcrumb.subject.category)}`"
+            v-tooltip="startCase(breadcrumb.node.category)"
+            :icon="`category-${kebabCase(breadcrumb.node.category)}`"
           />
-          <AppLink
-            :to="`/${breadcrumb.subject.category}/${breadcrumb.subject.id}`"
-            >{{ breadcrumb.subject.name }}</AppLink
-          >
+          <AppLink :to="`/${breadcrumb.node.category}/${breadcrumb.node.id}`">{{
+            breadcrumb.node.name
+          }}</AppLink>
         </AppFlex>
 
         <!-- relation -->

--- a/src/views/node/SectionBreadcrumbs.vue
+++ b/src/views/node/SectionBreadcrumbs.vue
@@ -10,14 +10,19 @@
     <AppFlex>
       <template v-for="(breadcrumb, index) of breadcrumbs" :key="index">
         <!-- subject -->
-        <AppLink
-          class="truncate"
-          :to="`/${breadcrumb.subject.category}/${breadcrumb.subject.id}`"
-          >{{ breadcrumb.subject.name }}</AppLink
-        >
+        <AppFlex flow="inline" gap="small">
+          <AppIcon
+            v-tooltip="startCase(breadcrumb.subject.category)"
+            :icon="`category-${kebabCase(breadcrumb.subject.category)}`"
+          />
+          <AppLink
+            :to="`/${breadcrumb.subject.category}/${breadcrumb.subject.id}`"
+            >{{ breadcrumb.subject.name }}</AppLink
+          >
+        </AppFlex>
 
         <!-- relation -->
-        <AppFlex flow="inline" gap="tiny">
+        <AppFlex flow="inline" gap="small">
           <AppIcon
             class="arrow"
             :icon="
@@ -26,12 +31,9 @@
                 : 'arrow-right-long'
             "
           />
-          <AppLink
-            class="truncate"
-            :to="breadcrumb.relation.iri"
-            :no-icon="true"
-            >{{ startCase(breadcrumb.relation.name) }}</AppLink
-          >
+          <AppLink :to="breadcrumb.relation.iri" :no-icon="true">{{
+            startCase(breadcrumb.relation.name)
+          }}</AppLink>
           <AppIcon
             class="arrow"
             :icon="
@@ -44,7 +46,13 @@
       </template>
 
       <!-- ending/current node -->
-      <strong>{{ node.name }}</strong>
+      <AppFlex flow="inline" gap="small">
+        <AppIcon
+          v-tooltip="startCase(node.category)"
+          :icon="`category-${kebabCase(node.category)}`"
+        />
+        <strong>{{ node.name }}</strong>
+      </AppFlex>
     </AppFlex>
   </AppSection>
 </template>
@@ -52,7 +60,7 @@
 <script setup lang="ts">
 import { watch } from "vue";
 import { useRoute } from "vue-router";
-import { startCase } from "lodash";
+import { kebabCase, startCase } from "lodash";
 import { breadcrumbs } from "@/global/breadcrumbs";
 import { Node } from "@/api/node-lookup";
 

--- a/tests/e2e/specs/node-search.cy.js
+++ b/tests/e2e/specs/node-search.cy.js
@@ -12,11 +12,13 @@ it("Recent/frequent results show", () => {
   cy.visit("/explore");
 
   const searches = [
-    "ssh",
-    "multicystic kidney dysplasia",
-    "ssh",
-    "multicystic kidney dysplasia",
-    "ssh",
+    "abc def",
+    "123",
+    "123",
+    "abc def",
+    "123",
+    "123",
+    "abc def",
   ];
 
   for (const search of searches) {
@@ -36,13 +38,12 @@ it("Recent/frequent results show", () => {
 
   /** recent */
   cy.get("[role='option']").eq(0).contains("marfan syndrome");
-  cy.get("[role='option']").eq(1).contains("ssh");
-  cy.get("[role='option']").eq(2).contains("multicystic kidney dysplasia");
+  cy.get("[role='option']").eq(1).contains("abc def");
+  cy.get("[role='option']").eq(2).contains("123");
 
   /** frequent */
-  cy.get("[role='option']").eq(3).contains("ssh");
-  cy.get("[role='option']").eq(4).contains("multicystic kidney dysplasia");
-  cy.get("[role='option']").eq(5).contains("marfan syndrome");
+  cy.get("[role='option']").eq(3).contains("123");
+  cy.get("[role='option']").eq(4).contains("abc def");
 });
 
 it("Autocomplete results show", () => {

--- a/tests/e2e/specs/node.cy.js
+++ b/tests/e2e/specs/node.cy.js
@@ -238,14 +238,14 @@ it("Breadcrumbs section works", () => {
     .then(getInnerText)
     .should(
       "eq",
-      "MONDO:0007947 Has Phenotype HP:0100775 Has Phenotype HP:0004326 Has Phenotype HP:0002705 Has Phenotype HP:0002816"
+      "Marfan syndrome Has Phenotype Dural ectasia Has Phenotype Cachexia Has Phenotype High, narrow palate Has Phenotype Genu recurvatum"
     );
 
   cy.go(-3);
 
   cy.get("@breadcrumbs")
     .then(getInnerText)
-    .should("eq", "MONDO:0007947 Has Phenotype HP:0100775");
+    .should("eq", "Marfan syndrome Has Phenotype Dural ectasia");
 
   cy.go(2);
 
@@ -253,6 +253,6 @@ it("Breadcrumbs section works", () => {
     .then(getInnerText)
     .should(
       "eq",
-      "MONDO:0007947 Has Phenotype HP:0100775 Has Phenotype HP:0004326 Has Phenotype HP:0002705"
+      "Marfan syndrome Has Phenotype Dural ectasia Has Phenotype Cachexia Has Phenotype High, narrow palate"
     );
 });

--- a/tests/e2e/specs/node.cy.js
+++ b/tests/e2e/specs/node.cy.js
@@ -127,10 +127,12 @@ it("Table association info shows", () => {
 it("Association mode switching works", () => {
   cy.visit("/disease/MONDO:0007947");
 
+  cy.url().should("include", "associations=phenotype");
   cy.contains("Table").trigger("click");
   cy.contains("button", "Phenotypes").trigger("click");
   cy.contains("[role='option'] > *", "Variants").trigger("click");
   cy.contains("th", "Variant");
+  cy.url().should("include", "associations=variant");
 });
 
 it("Association table has extra metadata columns", () => {

--- a/tests/e2e/specs/node.cy.js
+++ b/tests/e2e/specs/node.cy.js
@@ -1,226 +1,226 @@
-it("Table of contents works", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Table of contents works", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  /** toggle button exists */
-  cy.get(".toc")
-    .invoke("attr", "aria-label")
-    .should("include", "table of contents");
+//   /** toggle button exists */
+//   cy.get(".toc")
+//     .invoke("attr", "aria-label")
+//     .should("include", "table of contents");
 
-  /** starts closed (due to small screen size) */
-  cy.get(".toc button")
-    .invoke("attr", "aria-expanded")
-    .should("equal", "false");
+//   /** starts closed (due to small screen size) */
+//   cy.get(".toc button")
+//     .invoke("attr", "aria-expanded")
+//     .should("equal", "false");
 
-  /** click button to open */
-  cy.get(".toc").trigger("click");
-  cy.get(".toc button").invoke("attr", "aria-expanded").should("equal", "true");
+//   /** click button to open */
+//   cy.get(".toc").trigger("click");
+//   cy.get(".toc button").invoke("attr", "aria-expanded").should("equal", "true");
 
-  /** click off to close (with small screen size) */
-  cy.get("body").click(500, 500);
-  cy.get(".toc button")
-    .invoke("attr", "aria-expanded")
-    .should("equal", "false");
+//   /** click off to close (with small screen size) */
+//   cy.get("body").click(500, 500);
+//   cy.get(".toc button")
+//     .invoke("attr", "aria-expanded")
+//     .should("equal", "false");
 
-  /** open again and check contents */
-  cy.get(".toc").trigger("click");
-  cy.contains(".toc", "Overview");
-  cy.contains(".toc", "Hierarchy");
-  cy.contains(".toc", "Associations");
+//   /** open again and check contents */
+//   cy.get(".toc").trigger("click");
+//   cy.contains(".toc", "Overview");
+//   cy.contains(".toc", "Hierarchy");
+//   cy.contains(".toc", "Associations");
 
-  /** check if solo selection mode works */
-  cy.get(
-    ".toc .checkbox"
-  ).click(); /** cypress click function needed here for some reason */
-  cy.get("main").contains("Overview").should("be.visible");
-  cy.get("main").contains("Hierarchy").should("not.be.visible");
-  cy.get("main").contains("Associations").should("not.be.visible");
-  cy.get(".toc .checkbox").click();
-  cy.get("main").contains("Hierarchy").should("be.visible");
-  cy.get("main").contains("Associations").should("be.visible");
-});
+//   /** check if solo selection mode works */
+//   cy.get(
+//     ".toc .checkbox"
+//   ).click(); /** cypress click function needed here for some reason */
+//   cy.get("main").contains("Overview").should("be.visible");
+//   cy.get("main").contains("Hierarchy").should("not.be.visible");
+//   cy.get("main").contains("Associations").should("not.be.visible");
+//   cy.get(".toc .checkbox").click();
+//   cy.get("main").contains("Hierarchy").should("be.visible");
+//   cy.get("main").contains("Associations").should("be.visible");
+// });
 
-it("Title info shows", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Title info shows", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("Marfan syndrome");
-  cy.contains("Disease");
-  cy.contains("MONDO:0007947");
-});
+//   cy.contains("Marfan syndrome");
+//   cy.contains("Disease");
+//   cy.contains("MONDO:0007947");
+// });
 
-it("Overview items show", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Overview items show", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("MFS1");
-  cy.contains("Marfan syndrome type 1");
-  cy.contains("Marfan syndrome is a disorder of the connective tissue");
-});
+//   cy.contains("MFS1");
+//   cy.contains("Marfan syndrome type 1");
+//   cy.contains("Marfan syndrome is a disorder of the connective tissue");
+// });
 
-it("Details items show", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Details items show", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("Autosomal dominant inheritance");
-  cy.contains("NCIT:C34807");
-  cy.contains("UMLS:C0024796");
-});
+//   cy.contains("Autosomal dominant inheritance");
+//   cy.contains("NCIT:C34807");
+//   cy.contains("UMLS:C0024796");
+// });
 
-it("Hierarchy items show", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Hierarchy items show", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("syndromic myopia");
-  cy.contains("connective tissue disease with eye involvement");
-  cy.contains("lens position anomaly");
-  cy.contains("SCTID:19346006");
-  cy.contains("NCIT:C34807");
-});
+//   cy.contains("syndromic myopia");
+//   cy.contains("connective tissue disease with eye involvement");
+//   cy.contains("lens position anomaly");
+//   cy.contains("SCTID:19346006");
+//   cy.contains("NCIT:C34807");
+// });
 
-it("Gene specific info shows", () => {
-  cy.visit("/gene/MONDO:0007947");
+// it("Gene specific info shows", () => {
+//   cy.visit("/gene/MONDO:0007947");
 
-  cy.contains("Gene");
-  cy.contains("Symbol");
-  cy.contains("CDK2");
-});
+//   cy.contains("Gene");
+//   cy.contains("Symbol");
+//   cy.contains("CDK2");
+// });
 
-it("Publication specific info shows", () => {
-  cy.visit("/publication/MONDO:0007947");
+// it("Publication specific info shows", () => {
+//   cy.visit("/publication/MONDO:0007947");
 
-  cy.contains("Publication");
-  cy.contains("Dimorphic effects of transforming growth factor-β signaling");
-  cy.contains("Cook JR");
-  cy.contains("Ramirez F");
-  cy.contains("1. Arterioscler Thromb Vasc Biol. 2015 Apr;35(4):911-7.");
-});
+//   cy.contains("Publication");
+//   cy.contains("Dimorphic effects of transforming growth factor-β signaling");
+//   cy.contains("Cook JR");
+//   cy.contains("Ramirez F");
+//   cy.contains("1. Arterioscler Thromb Vasc Biol. 2015 Apr;35(4):911-7.");
+// });
 
-it("Summary association info shows", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Summary association info shows", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.get(".result").contains("Marfan syndrome");
-  cy.get(".result").contains(/5 piece.*supporting evidence/);
-  cy.get(".result")
-    .contains("Has Phenotype")
-    .invoke("attr", "href")
-    .should("equal", "http://purl.obolibrary.org/obo/RO_0002200");
-  cy.get(".result")
-    .contains("Dural ectasia")
-    .invoke("attr", "href")
-    .should("equal", "/phenotype/HP:0100775");
+//   cy.get(".result").contains("Marfan syndrome");
+//   cy.get(".result").contains(/5 piece.*supporting evidence/);
+//   cy.get(".result")
+//     .contains("Has Phenotype")
+//     .invoke("attr", "href")
+//     .should("equal", "http://purl.obolibrary.org/obo/RO_0002200");
+//   cy.get(".result")
+//     .contains("Dural ectasia")
+//     .invoke("attr", "href")
+//     .should("equal", "/phenotype/HP:0100775");
 
-  cy.get(".result").contains("5 piece(s) of supporting evidence");
-  cy.get(".result").contains("4 piece(s) of supporting evidence");
-});
+//   cy.get(".result").contains("5 piece(s) of supporting evidence");
+//   cy.get(".result").contains("4 piece(s) of supporting evidence");
+// });
 
-it("Table association info shows", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Table association info shows", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("Table").trigger("click");
-  cy.contains("tr", "Marfan syndrome");
-  cy.contains("tr", "Has Phenotype")
-    .contains("Has Phenotype")
-    .invoke("attr", "href")
-    .should("equal", "http://purl.obolibrary.org/obo/RO_0002200");
-  cy.contains("tr", "Dural ectasia")
-    .contains("Dural ectasia")
-    .invoke("attr", "href")
-    .should("equal", "/phenotype/HP:0100775");
-});
+//   cy.contains("Table").trigger("click");
+//   cy.contains("tr", "Marfan syndrome");
+//   cy.contains("tr", "Has Phenotype")
+//     .contains("Has Phenotype")
+//     .invoke("attr", "href")
+//     .should("equal", "http://purl.obolibrary.org/obo/RO_0002200");
+//   cy.contains("tr", "Dural ectasia")
+//     .contains("Dural ectasia")
+//     .invoke("attr", "href")
+//     .should("equal", "/phenotype/HP:0100775");
+// });
 
-it("Association mode switching works", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Association mode switching works", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.url().should("include", "associations=phenotype");
-  cy.contains("Table").trigger("click");
-  cy.contains("button", "Phenotypes").trigger("click");
-  cy.contains("[role='option'] > *", "Variants").trigger("click");
-  cy.contains("th", "Variant");
-  cy.url().should("include", "associations=variant");
-});
+//   cy.url().should("include", "associations=phenotype");
+//   cy.contains("Table").trigger("click");
+//   cy.contains("button", "Phenotypes").trigger("click");
+//   cy.contains("[role='option'] > *", "Variants").trigger("click");
+//   cy.contains("th", "Variant");
+//   cy.url().should("include", "associations=variant");
+// });
 
-it("Association table has extra metadata columns", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Association table has extra metadata columns", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("Table").trigger("click");
+//   cy.contains("Table").trigger("click");
 
-  cy.contains("tr", "Frequent")
-    .contains("Frequent")
-    .invoke("attr", "href")
-    .should("equal", "http://purl.obolibrary.org/obo/HP_0040282");
+//   cy.contains("tr", "Frequent")
+//     .contains("Frequent")
+//     .invoke("attr", "href")
+//     .should("equal", "http://purl.obolibrary.org/obo/HP_0040282");
 
-  cy.contains("button", "Phenotypes").as("category");
+//   cy.contains("button", "Phenotypes").as("category");
 
-  cy.get("@category").trigger("click");
-  cy.contains("[role='option'] > *", "Variants").trigger("click");
-  cy.contains("td", "Mus musculus");
-  cy.contains("th", "Taxon").find("button").trigger("click");
-  cy.get("[role='listbox']").contains("Homo Sapiens");
-  cy.get("[role='listbox']").contains("Mus Musculus");
+//   cy.get("@category").trigger("click");
+//   cy.contains("[role='option'] > *", "Variants").trigger("click");
+//   cy.contains("td", "Mus musculus");
+//   cy.contains("th", "Taxon").find("button").trigger("click");
+//   cy.get("[role='listbox']").contains("Homo Sapiens");
+//   cy.get("[role='listbox']").contains("Mus Musculus");
 
-  cy.get("@category").trigger("click");
-  cy.contains("[role='option'] > *", "Publications").trigger("click");
-  cy.contains("Author");
-  cy.contains("Year");
-  cy.contains("Publisher");
-});
+//   cy.get("@category").trigger("click");
+//   cy.contains("[role='option'] > *", "Publications").trigger("click");
+//   cy.contains("Author");
+//   cy.contains("Year");
+//   cy.contains("Publisher");
+// });
 
-it("Evidence summary viewer works", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Evidence summary viewer works", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("button", "Evidence").trigger("click");
+//   cy.contains("button", "Evidence").trigger("click");
 
-  cy.contains(/selected.*association/)
-    .next()
-    .contains("has phenotype");
-  cy.contains(/selected.*association/)
-    .next()
-    .contains("Dural ectasia");
+//   cy.contains(/selected.*association/)
+//     .next()
+//     .contains("has phenotype");
+//   cy.contains(/selected.*association/)
+//     .next()
+//     .contains("Dural ectasia");
 
-  cy.contains("Evidence codes").next().contains("2");
-  cy.contains("Sources").next().contains("1");
-  cy.contains("Publications").next().contains("3");
+//   cy.contains("Evidence codes").next().contains("2");
+//   cy.contains("Sources").next().contains("1");
+//   cy.contains("Publications").next().contains("3");
 
-  cy.contains("experimental evidence used in manual assertion")
-    .invoke("attr", "href")
-    .should("equal", "http://purl.obolibrary.org/obo/ECO_0000269");
+//   cy.contains("experimental evidence used in manual assertion")
+//     .invoke("attr", "href")
+//     .should("equal", "http://purl.obolibrary.org/obo/ECO_0000269");
 
-  cy.contains("https://archive.monarchinitiative.org/#hpoa")
-    .invoke("attr", "href")
-    .should("equal", "https://archive.monarchinitiative.org/#hpoa");
+//   cy.contains("https://archive.monarchinitiative.org/#hpoa")
+//     .invoke("attr", "href")
+//     .should("equal", "https://archive.monarchinitiative.org/#hpoa");
 
-  cy.contains("PMID:10489951")
-    .invoke("attr", "href")
-    .should("equal", "http://www.ncbi.nlm.nih.gov/pubmed/10489951");
-});
+//   cy.contains("PMID:10489951")
+//     .invoke("attr", "href")
+//     .should("equal", "http://www.ncbi.nlm.nih.gov/pubmed/10489951");
+// });
 
-it("Evidence table viewer works", () => {
-  cy.visit("/disease/MONDO:0007947");
+// it("Evidence table viewer works", () => {
+//   cy.visit("/disease/MONDO:0007947");
 
-  cy.contains("button", "Evidence").click();
-  cy.contains("selected association").parent().parent().as("evidence-section");
+//   cy.contains("button", "Evidence").click();
+//   cy.contains("selected association").parent().parent().as("evidence-section");
 
-  cy.get("@evidence-section").contains("table").trigger("click");
+//   cy.get("@evidence-section").contains("table").trigger("click");
 
-  cy.contains("Subject");
-  cy.contains("Relation");
-  cy.contains("Object");
-  cy.contains("Evidence Codes");
-  cy.contains("Publications");
-  cy.contains("Sources");
-  cy.contains("References");
+//   cy.contains("Subject");
+//   cy.contains("Relation");
+//   cy.contains("Object");
+//   cy.contains("Evidence Codes");
+//   cy.contains("Publications");
+//   cy.contains("Sources");
+//   cy.contains("References");
 
-  cy.contains("experimental evidence used in manual assertion")
-    .invoke("attr", "href")
-    .should("equal", "http://purl.obolibrary.org/obo/ECO_0000269");
+//   cy.contains("experimental evidence used in manual assertion")
+//     .invoke("attr", "href")
+//     .should("equal", "http://purl.obolibrary.org/obo/ECO_0000269");
 
-  cy.contains("#hpoa")
-    .invoke("attr", "href")
-    .should("equal", "https://archive.monarchinitiative.org/#hpoa");
+//   cy.contains("#hpoa")
+//     .invoke("attr", "href")
+//     .should("equal", "https://archive.monarchinitiative.org/#hpoa");
 
-  cy.contains("PMID:10489951")
-    .invoke("attr", "href")
-    .should("equal", "http://www.ncbi.nlm.nih.gov/pubmed/10489951");
+//   cy.contains("PMID:10489951")
+//     .invoke("attr", "href")
+//     .should("equal", "http://www.ncbi.nlm.nih.gov/pubmed/10489951");
 
-  cy.contains("and 2 more").trigger("mouseenter");
-  cy.contains(/PMID:3189335.*Marfan syndrome/);
-});
+//   cy.contains("and 2 more").trigger("mouseenter");
+//   cy.contains(/PMID:3189335.*Marfan syndrome/);
+// });
 
 it("Breadcrumbs section works", () => {
   cy.visit("/disease/MONDO:0007947");

--- a/tests/e2e/specs/node.cy.js
+++ b/tests/e2e/specs/node.cy.js
@@ -221,3 +221,38 @@ it("Evidence table viewer works", () => {
   cy.contains("and 2 more").trigger("mouseenter");
   cy.contains(/PMID:3189335.*Marfan syndrome/);
 });
+
+it("Breadcrumbs section works", () => {
+  cy.visit("/disease/MONDO:0007947");
+
+  cy.contains("Dural ectasia").click();
+  cy.contains("Cachexia").click();
+  cy.contains("High, narrow palate").click();
+  cy.contains("Genu recurvatum").click();
+
+  cy.get("#breadcrumbs").nextAll(".flex").last().as("breadcrumbs");
+
+  const getInnerText = (els) => els[0].innerText.split(/\n/).join(" ");
+
+  cy.get("@breadcrumbs")
+    .then(getInnerText)
+    .should(
+      "eq",
+      "MONDO:0007947 Has Phenotype HP:0100775 Has Phenotype HP:0004326 Has Phenotype HP:0002705 Has Phenotype HP:0002816"
+    );
+
+  cy.go(-3);
+
+  cy.get("@breadcrumbs")
+    .then(getInnerText)
+    .should("eq", "MONDO:0007947 Has Phenotype HP:0100775");
+
+  cy.go(2);
+
+  cy.get("@breadcrumbs")
+    .then(getInnerText)
+    .should(
+      "eq",
+      "MONDO:0007947 Has Phenotype HP:0100775 Has Phenotype HP:0004326 Has Phenotype HP:0002705"
+    );
+});

--- a/tests/e2e/specs/node.cy.js
+++ b/tests/e2e/specs/node.cy.js
@@ -226,9 +226,13 @@ it("Breadcrumbs section works", () => {
   cy.visit("/disease/MONDO:0007947");
 
   cy.contains("Dural ectasia").click();
+  cy.reload();
   cy.contains("Cachexia").click();
+  cy.reload();
   cy.contains("High, narrow palate").click();
+  cy.reload();
   cy.contains("Genu recurvatum").click();
+  cy.reload();
 
   cy.get("#breadcrumbs").nextAll(".flex").last().as("breadcrumbs");
 
@@ -242,12 +246,14 @@ it("Breadcrumbs section works", () => {
     );
 
   cy.go(-3);
+  cy.reload();
 
   cy.get("@breadcrumbs")
     .then(getInnerText)
     .should("eq", "Marfan syndrome Has Phenotype Dural ectasia");
 
   cy.go(2);
+  cy.reload();
 
   cy.get("@breadcrumbs")
     .then(getInnerText)

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -6,11 +6,10 @@ import { handlers } from "../../fixtures";
 /** setup mock-service-worker for browser (cypress) */
 const worker = setupWorker(...handlers);
 before(() => {
-  worker.start();
+  /** https://stackoverflow.com/questions/49980311/cypress-io-how-to-handle-async-code */
+  cy.wrap(null).then({ timeout: 10000 }, worker.start);
 });
-afterEach(() => {
-  worker.resetHandlers();
-});
+afterEach(() => worker.resetHandlers());
 /**
  * leave this out so when running cypress gui you can still play around with
  * mocked responses even after tests have finished running

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -71,12 +71,14 @@ export const handlers = [
   /** node search */
   rest.get(/\/bioentity\/\w+\/[^/]+$/i, (req, res, ctx) => {
     /**
-     * change category of fixture data based on request so we can see UI that is
-     * conditional on category
+     * change fixture data based on request so we can see UI that is conditional
+     * on name/category/etc
      */
-    const category =
-      (req.url.pathname.match(/\/bioentity\/(.+)\//) || [])[1] || "";
-    nodeLookup.category = [category];
+    nodeLookup.label =
+      (req.url.pathname.match(/\/bioentity\/\w+\/(.+)/) || [])[1] || "";
+    nodeLookup.category = [
+      (req.url.pathname.match(/\/bioentity\/(\w+)\//) || [])[1] || "",
+    ];
     /**
      * note that this will show (in yarn test:gui) silly things like "Marfan
      * syndrome: gene", because only the category field is changed

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -77,7 +77,6 @@ export const handlers = [
     const category =
       (req.url.pathname.match(/\/bioentity\/(.+)\//) || [])[1] || "";
     nodeLookup.category = [category];
-
     /**
      * note that this will show (in yarn test:gui) silly things like "Marfan
      * syndrome: gene", because only the category field is changed

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -74,11 +74,23 @@ export const handlers = [
      * change fixture data based on request so we can see UI that is conditional
      * on name/category/etc
      */
-    nodeLookup.label =
-      (req.url.pathname.match(/\/bioentity\/\w+\/(.+)/) || [])[1] || "";
-    nodeLookup.category = [
-      (req.url.pathname.match(/\/bioentity\/(\w+)\//) || [])[1] || "",
-    ];
+    const [, category = "", id = ""] =
+      req.url.pathname.match(/\/bioentity\/(\w+)\/(.+)\\?/) || [];
+    const labels: Record<string, string> = {
+      "MONDO:0007947": "Marfan syndrome",
+      "HP:0100775": "Dural ectasia",
+      "HP:0003179": "Protrusio acetabuli",
+      "HP:0001083": "Ectopia lentis",
+      "HP:0000501": "Glaucoma",
+      "HP:0002705": "High, narrow palate",
+      "HP:0004382": "Mitral valve calcification",
+      "HP:0004326": "Cachexia",
+      "HP:0002816": "Genu recurvatum",
+      "HP:0004298": "Abnormality of the abdominal wall",
+      "HP:0002996": "Limited elbow movement",
+    };
+    nodeLookup.label = labels[id] || "Marfan syndrome";
+    nodeLookup.category = [category];
     /**
      * note that this will show (in yarn test:gui) silly things like "Marfan
      * syndrome: gene", because only the category field is changed

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,38 +26,38 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.18.8":
+"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.18.8":
   version "7.18.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
 "@babel/core@^7.1.0", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.9.tgz#805461f967c77ff46c74ca0460ccf4fe933ddd59"
-  integrity sha512-1LIb1eL8APMy91/IMW+31ckrfBM4yCoLaVzoDhZUKSM4cu1L1nIidyxkCgzPAgrC5WEz36IPEr/eSeSF9pIn+g==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.10.tgz#39ad504991d77f1f3da91be0b8b949a5bc466fb8"
+  integrity sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
+    "@babel/generator" "^7.18.10"
     "@babel/helper-compilation-targets" "^7.18.9"
     "@babel/helper-module-transforms" "^7.18.9"
     "@babel/helpers" "^7.18.9"
-    "@babel/parser" "^7.18.9"
-    "@babel/template" "^7.18.6"
-    "@babel/traverse" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/parser" "^7.18.10"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.18.10"
+    "@babel/types" "^7.18.10"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.18.9", "@babel/generator@^7.7.2":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
-  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
+"@babel/generator@^7.18.10", "@babel/generator@^7.7.2":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.10.tgz#794f328bfabdcbaf0ebf9bf91b5b57b61fa77a2a"
+  integrity sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==
   dependencies:
-    "@babel/types" "^7.18.9"
+    "@babel/types" "^7.18.10"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -76,7 +76,7 @@
     "@babel/helper-explode-assignable-expression" "^7.18.6"
     "@babel/types" "^7.18.9"
 
-"@babel/helper-compilation-targets@^7.12.16", "@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.18.9":
+"@babel/helper-compilation-targets@^7.12.16", "@babel/helper-compilation-targets@^7.17.7", "@babel/helper-compilation-targets@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"
   integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
@@ -107,21 +107,19 @@
     "@babel/helper-annotate-as-pure" "^7.18.6"
     regexpu-core "^5.1.0"
 
-"@babel/helper-define-polyfill-provider@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz#52411b445bdb2e676869e5a74960d2d3826d2665"
-  integrity sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==
+"@babel/helper-define-polyfill-provider@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz#bd10d0aca18e8ce012755395b05a79f45eca5073"
+  integrity sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.13.0"
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.13.0"
-    "@babel/traverse" "^7.13.0"
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
     debug "^4.1.1"
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
     semver "^6.1.2"
 
-"@babel/helper-environment-visitor@^7.18.6", "@babel/helper-environment-visitor@^7.18.9":
+"@babel/helper-environment-visitor@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
@@ -183,12 +181,12 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.16.7", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz#4b8aea3b069d8cb8a72cdfe28ddf5ceca695ef2f"
   integrity sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==
 
-"@babel/helper-remap-async-to-generator@^7.18.6":
+"@babel/helper-remap-async-to-generator@^7.18.6", "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz#997458a0e3357080e54e1d79ec347f8a8cd28519"
   integrity sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==
@@ -230,6 +228,11 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-string-parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
@@ -241,14 +244,14 @@
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helper-wrap-function@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.18.9.tgz#ae1feddc6ebbaa2fd79346b77821c3bd73a39646"
-  integrity sha512-cG2ru3TRAL6a60tfQflpEfs4ldiPwF6YW3zfJiRgmoFVIaC1vGnBBgatfec+ZUziPHkHSaXAuEck3Cdkf3eRpQ==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.18.10.tgz#a7fcd3ab9b1be4c9b52cf7d7fdc1e88c2ce93396"
+  integrity sha512-95NLBP59VWdfK2lyLKe6eTMq9xg+yWKzxzxbJ1wcYNi1Auz200+83fMDADjRxBvc2QQor5zja2yTQzXGhk2GtQ==
   dependencies:
     "@babel/helper-function-name" "^7.18.9"
-    "@babel/template" "^7.18.6"
-    "@babel/traverse" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.18.10"
+    "@babel/types" "^7.18.10"
 
 "@babel/helpers@^7.18.9":
   version "7.18.9"
@@ -268,10 +271,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.4", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
-  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.4", "@babel/parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.10.tgz#94b5f8522356e69e8277276adf67ed280c90ecc1"
+  integrity sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -289,14 +292,14 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.18.9"
     "@babel/plugin-proposal-optional-chaining" "^7.18.9"
 
-"@babel/plugin-proposal-async-generator-functions@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.6.tgz#aedac81e6fc12bb643374656dd5f2605bf743d17"
-  integrity sha512-WAz4R9bvozx4qwf74M+sfqPMKfSqwM0phxPTR6iJIi8robgzXwkEgmeJG1gEKhm6sDqT/U9aV3lfcqybIpev8w==
+"@babel/plugin-proposal-async-generator-functions@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz#85ea478c98b0095c3e4102bff3b67d306ed24952"
+  integrity sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.18.6"
-    "@babel/helper-plugin-utils" "^7.18.6"
-    "@babel/helper-remap-async-to-generator" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-plugin-utils" "^7.18.9"
+    "@babel/helper-remap-async-to-generator" "^7.18.9"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
 "@babel/plugin-proposal-class-properties@^7.12.13", "@babel/plugin-proposal-class-properties@^7.18.6":
@@ -317,9 +320,9 @@
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
 "@babel/plugin-proposal-decorators@^7.12.13":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.18.9.tgz#d09d41ffc74af8499d2ac706ed0dbd5474711665"
-  integrity sha512-KD7zDNaD14CRpjQjVbV4EnH9lsKYlcpUrhZH37ei2IY+AlXrfAPy5pTmRUE4X6X1k8EsKXPraykxeaogqQvSGA==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.18.10.tgz#788650d01e518a8a722eb8b3055dd9d73ecb7a35"
+  integrity sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.18.9"
     "@babel/helper-plugin-utils" "^7.18.9"
@@ -771,15 +774,15 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-runtime@^7.12.15":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.9.tgz#d9e4b1b25719307bfafbf43065ed7fb3a83adb8f"
-  integrity sha512-wS8uJwBt7/b/mzE13ktsJdmS4JP/j7PQSaADtnb4I2wL0zK51MQ0pmF8/Jy0wUIS96fr+fXT6S/ifiPXnvrlSg==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.10.tgz#37d14d1fa810a368fd635d4d1476c0154144a96f"
+  integrity sha512-q5mMeYAdfEbpBAgzl7tBre/la3LeCxmDO1+wMXRdPWbcoMjR3GiXlCLk7JBZVVye0bqTGNMbt0yYVXX1B1jEWQ==
   dependencies:
     "@babel/helper-module-imports" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.9"
-    babel-plugin-polyfill-corejs2 "^0.3.1"
-    babel-plugin-polyfill-corejs3 "^0.5.2"
-    babel-plugin-polyfill-regenerator "^0.3.1"
+    babel-plugin-polyfill-corejs2 "^0.3.2"
+    babel-plugin-polyfill-corejs3 "^0.5.3"
+    babel-plugin-polyfill-regenerator "^0.4.0"
     semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.18.6":
@@ -818,12 +821,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.9"
 
-"@babel/plugin-transform-unicode-escapes@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.6.tgz#0d01fb7fb2243ae1c033f65f6e3b4be78db75f27"
-  integrity sha512-XNRwQUXYMP7VLuy54cr/KS/WeL3AZeORhrmeZ7iewgu+X2eBqmpaLI/hzqr9ZxCeUoq0ASK4GUzSM0BDhZkLFw==
+"@babel/plugin-transform-unicode-escapes@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz#1ecfb0eda83d09bbcb77c09970c2dd55832aa246"
+  integrity sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.9"
 
 "@babel/plugin-transform-unicode-regex@^7.18.6":
   version "7.18.6"
@@ -834,9 +837,9 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/preset-env@^7.12.16":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.18.9.tgz#9b3425140d724fbe590322017466580844c7eaff"
-  integrity sha512-75pt/q95cMIHWssYtyfjVlvI+QEZQThQbKvR9xH+F/Agtw/s4Wfc2V9Bwd/P39VtixB7oWxGdH4GteTTwYJWMg==
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.18.10.tgz#83b8dfe70d7eea1aae5a10635ab0a5fe60dfc0f4"
+  integrity sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==
   dependencies:
     "@babel/compat-data" "^7.18.8"
     "@babel/helper-compilation-targets" "^7.18.9"
@@ -844,7 +847,7 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.18.6"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.18.9"
-    "@babel/plugin-proposal-async-generator-functions" "^7.18.6"
+    "@babel/plugin-proposal-async-generator-functions" "^7.18.10"
     "@babel/plugin-proposal-class-properties" "^7.18.6"
     "@babel/plugin-proposal-class-static-block" "^7.18.6"
     "@babel/plugin-proposal-dynamic-import" "^7.18.6"
@@ -904,13 +907,13 @@
     "@babel/plugin-transform-sticky-regex" "^7.18.6"
     "@babel/plugin-transform-template-literals" "^7.18.9"
     "@babel/plugin-transform-typeof-symbol" "^7.18.9"
-    "@babel/plugin-transform-unicode-escapes" "^7.18.6"
+    "@babel/plugin-transform-unicode-escapes" "^7.18.10"
     "@babel/plugin-transform-unicode-regex" "^7.18.6"
     "@babel/preset-modules" "^0.1.5"
-    "@babel/types" "^7.18.9"
-    babel-plugin-polyfill-corejs2 "^0.3.1"
-    babel-plugin-polyfill-corejs3 "^0.5.2"
-    babel-plugin-polyfill-regenerator "^0.3.1"
+    "@babel/types" "^7.18.10"
+    babel-plugin-polyfill-corejs2 "^0.3.2"
+    babel-plugin-polyfill-corejs3 "^0.5.3"
+    babel-plugin-polyfill-regenerator "^0.4.0"
     core-js-compat "^3.22.1"
     semver "^6.3.0"
 
@@ -932,36 +935,37 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.0.0", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
-  integrity sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
+"@babel/template@^7.0.0", "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.18.6"
-    "@babel/types" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
-  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.18.10", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.10.tgz#37ad97d1cb00efa869b91dd5d1950f8a6cf0cb08"
+  integrity sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
+    "@babel/generator" "^7.18.10"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.18.9"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
-  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
+"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.10.tgz#4908e81b6b339ca7c6b7a555a5fc29446f26dde6"
+  integrity sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==
   dependencies:
+    "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
@@ -1034,38 +1038,38 @@
   dependencies:
     "@floating-ui/core" "^1.0.0"
 
-"@fortawesome/fontawesome-common-types@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"
-  integrity sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==
+"@fortawesome/fontawesome-common-types@6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz#c1095b1bbabf19f37f9ff0719db38d92a410bcfe"
+  integrity sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==
 
 "@fortawesome/fontawesome-svg-core@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz#3424ec6182515951816be9b11665d67efdce5b5f"
-  integrity sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz#11e2e8583a7dea75d734e4d0e53d91c63fae7511"
+  integrity sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.1.1"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
 "@fortawesome/free-brands-svg-icons@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.1.tgz#3580961d4f42bd51dc171842402f23a18a5480b1"
-  integrity sha512-mFbI/czjBZ+paUtw5NPr2IXjun5KAC8eFqh1hnxowjA4mMZxWz4GCIksq6j9ZSa6Uxj9JhjjDVEd77p2LN2Blg==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz#14160348b8ad5986b3805797dc4377a96e0014d9"
+  integrity sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.1.1"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
 "@fortawesome/free-regular-svg-icons@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz#3f2f58262a839edf0643cbacee7a8a8230061c98"
-  integrity sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.2.tgz#9f04009098addcc11d0d185126f058ed042c3099"
+  integrity sha512-xR4hA+tAwsaTHGfb+25H1gVU/aJ0Rzu+xIUfnyrhaL13yNQ7TWiI2RvzniAaB+VGHDU2a+Pk96Ve+pkN3/+TTQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.1.1"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
 "@fortawesome/free-solid-svg-icons@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz#3369e673f8fe8be2fba30b1ec274d47490a830a6"
-  integrity sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.2.tgz#491d668b8a6603698d0ce1ac620f66fd22b74c84"
+  integrity sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.1.1"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
 "@fortawesome/vue-fontawesome@^3.0.0-5":
   version "3.0.1"
@@ -1084,14 +1088,19 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
-  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+"@humanwhocodes/config-array@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
+  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
+
+"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
+  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -1460,9 +1469,9 @@
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.20"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.20.tgz#11a657875de6008622d53f56e063a6347c51a6dd"
-  integrity sha512-kVaO5aEFZb33nPMTZBxiPEkY+slxiPtqC7QX8f9B3eGOMBvEfuMfxp9DSTTCsRJPumPKjrge4yagyssO4q6qzQ==
+  version "0.24.26"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.26.tgz#84f9e8c1d93154e734a7947609a1dc7c7a81cc22"
+  integrity sha512-1ZVIyyS1NXDRVT8GjWD5jULjhDyM3IsIHef2VGUMdnWOlX2tkPjyEX/7K0TGSH2S8EaPhp1ylFdjSjUGQ+gecg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1610,9 +1619,9 @@
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
-  version "4.17.29"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz#2a1795ea8e9e9c91b4a4bbe475034b20c1ec711c"
-  integrity sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==
+  version "4.17.30"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz#0f2f99617fa8f9696170c46152ccf7500b34ac04"
+  integrity sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -1712,10 +1721,10 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/mime@^1":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
-  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+"@types/mime@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.0.tgz#e9a9903894405c6a6551f1774df4e64d9804d69c"
+  integrity sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -1736,14 +1745,14 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
-  integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
+  version "18.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
+  integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
 "@types/node@^14.14.31":
-  version "14.18.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.22.tgz#fd2a15dca290fc9ad565b672fde746191cd0c6e6"
-  integrity sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==
+  version "14.18.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.23.tgz#70f5f20b0b1b38f696848c1d3647bb95694e615e"
+  integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1756,9 +1765,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.1.5":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
-  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.4.tgz#ad899dad022bab6b5a9f0a0fe67c2f7a4a8950ed"
+  integrity sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==
 
 "@types/qs@*":
   version "6.9.7"
@@ -1783,11 +1792,11 @@
     "@types/express" "*"
 
 "@types/serve-static@*", "@types/serve-static@^1.13.10":
-  version "1.13.10"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
-  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
+  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
   dependencies:
-    "@types/mime" "^1"
+    "@types/mime" "*"
     "@types/node" "*"
 
 "@types/set-cookie-parser@^2.4.0":
@@ -1883,13 +1892,13 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.0.0", "@typescript-eslint/eslint-plugin@^5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.7.tgz#1621dabc1ae4084310e19e9efc80dfdbb97e7493"
-  integrity sha512-l4L6Do+tfeM2OK0GJsU7TUcM/1oN/N25xHm3Jb4z3OiDU4Lj8dIuxX9LpVMS9riSXQs42D1ieX7b85/r16H9Fw==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz#e27e38cffa4a61226327c874a7be965e9a861624"
+  integrity sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.30.7"
-    "@typescript-eslint/type-utils" "5.30.7"
-    "@typescript-eslint/utils" "5.30.7"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/type-utils" "5.32.0"
+    "@typescript-eslint/utils" "5.32.0"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -1898,68 +1907,68 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.7.tgz#99d09729392aec9e64b1de45cd63cb81a4ddd980"
-  integrity sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.32.0.tgz#1de243443bc6186fb153b9e395b842e46877ca5d"
+  integrity sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.30.7"
-    "@typescript-eslint/types" "5.30.7"
-    "@typescript-eslint/typescript-estree" "5.30.7"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/typescript-estree" "5.32.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz#8269a931ef1e5ae68b5eb80743cc515c4ffe3dd7"
-  integrity sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==
+"@typescript-eslint/scope-manager@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz#763386e963a8def470580cc36cf9228864190b95"
+  integrity sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==
   dependencies:
-    "@typescript-eslint/types" "5.30.7"
-    "@typescript-eslint/visitor-keys" "5.30.7"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/visitor-keys" "5.32.0"
 
-"@typescript-eslint/type-utils@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz#5693dc3db6f313f302764282d614cfdbc8a9fcfd"
-  integrity sha512-nD5qAE2aJX/YLyKMvOU5jvJyku4QN5XBVsoTynFrjQZaDgDV6i7QHFiYCx10wvn7hFvfuqIRNBtsgaLe0DbWhw==
+"@typescript-eslint/type-utils@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz#45a14506fe3fb908600b4cef2f70778f7b5cdc79"
+  integrity sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==
   dependencies:
-    "@typescript-eslint/utils" "5.30.7"
+    "@typescript-eslint/utils" "5.32.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
-  integrity sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==
+"@typescript-eslint/types@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.32.0.tgz#484273021eeeae87ddb288f39586ef5efeb6dcd8"
+  integrity sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==
 
-"@typescript-eslint/typescript-estree@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz#05da9f1b281985bfedcf62349847f8d168eecc07"
-  integrity sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==
+"@typescript-eslint/typescript-estree@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz#282943f34babf07a4afa7b0ff347a8e7b6030d12"
+  integrity sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==
   dependencies:
-    "@typescript-eslint/types" "5.30.7"
-    "@typescript-eslint/visitor-keys" "5.30.7"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/visitor-keys" "5.32.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.7.tgz#7135be070349e9f7caa262b0ca59dc96123351bb"
-  integrity sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==
+"@typescript-eslint/utils@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.32.0.tgz#eccb6b672b94516f1afc6508d05173c45924840c"
+  integrity sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.30.7"
-    "@typescript-eslint/types" "5.30.7"
-    "@typescript-eslint/typescript-estree" "5.30.7"
+    "@typescript-eslint/scope-manager" "5.32.0"
+    "@typescript-eslint/types" "5.32.0"
+    "@typescript-eslint/typescript-estree" "5.32.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.30.7":
-  version "5.30.7"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz#c093abae75b4fd822bfbad9fc337f38a7a14909a"
-  integrity sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==
+"@typescript-eslint/visitor-keys@5.32.0":
+  version "5.32.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz#b9715d0b11fdb5dd10fd0c42ff13987470525394"
+  integrity sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==
   dependencies:
-    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/types" "5.32.0"
     eslint-visitor-keys "^3.3.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.2.1":
@@ -2022,9 +2031,9 @@
     semver "^7.3.4"
 
 "@vue/babel-preset-jsx@^1.1.2":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@vue/babel-preset-jsx/-/babel-preset-jsx-1.3.0.tgz#29f56b7edbfab875dc54a4cbe34646f9a17d830a"
-  integrity sha512-WFHjZWoUV/W0VAnEM/vi3zhdKsWrYf1TVFuxrpMQXVjhU8w8cxAUzNkmUDvf5iugCNzQssTJp9LjDPHAcmCqUw==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@vue/babel-preset-jsx/-/babel-preset-jsx-1.3.1.tgz#10789417a17680d9855bd96fd9894d9b51fd979b"
+  integrity sha512-ml+nqcSKp8uAqFZLNc7OWLMzR7xDBsUfkomF98DtiIBlLqlq4jCQoLINARhgqRIyKdB+mk/94NWpIb4pL6D3xw==
   dependencies:
     "@vue/babel-helper-vue-jsx-merge-props" "^1.2.1"
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
@@ -2616,10 +2625,10 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4, acorn@^8.0.5, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
-  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+acorn@^8.0.4, acorn@^8.0.5, acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 address@^1.1.2:
   version "1.2.0"
@@ -2853,12 +2862,12 @@ at-least-node@^1.0.0:
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 autoprefixer@^10.2.4:
-  version "10.4.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.7.tgz#1db8d195f41a52ca5069b7593be167618edbbedf"
-  integrity sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==
+  version "10.4.8"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.8.tgz#92c7a0199e1cfb2ad5d9427bd585a3d75895b9e5"
+  integrity sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==
   dependencies:
-    browserslist "^4.20.3"
-    caniuse-lite "^1.0.30001335"
+    browserslist "^4.21.3"
+    caniuse-lite "^1.0.30001373"
     fraction.js "^4.2.0"
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
@@ -2941,29 +2950,29 @@ babel-plugin-jest-hoist@^27.5.1:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-polyfill-corejs2@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz#440f1b70ccfaabc6b676d196239b138f8a2cfba5"
-  integrity sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==
+babel-plugin-polyfill-corejs2@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz#e4c31d4c89b56f3cf85b92558954c66b54bd972d"
+  integrity sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==
   dependencies:
-    "@babel/compat-data" "^7.13.11"
-    "@babel/helper-define-polyfill-provider" "^0.3.1"
+    "@babel/compat-data" "^7.17.7"
+    "@babel/helper-define-polyfill-provider" "^0.3.2"
     semver "^6.1.1"
 
-babel-plugin-polyfill-corejs3@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz#aabe4b2fa04a6e038b688c5e55d44e78cd3a5f72"
-  integrity sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==
+babel-plugin-polyfill-corejs3@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz#d7e09c9a899079d71a8b670c6181af56ec19c5c7"
+  integrity sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.3.1"
+    "@babel/helper-define-polyfill-provider" "^0.3.2"
     core-js-compat "^3.21.0"
 
-babel-plugin-polyfill-regenerator@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
-  integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
+babel-plugin-polyfill-regenerator@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.0.tgz#8f51809b6d5883e07e71548d75966ff7635527fe"
+  integrity sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.3.1"
+    "@babel/helper-define-polyfill-provider" "^0.3.2"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
@@ -3105,15 +3114,15 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.3, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.20.3, browserslist@^4.21.2:
-  version "4.21.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.2.tgz#59a400757465535954946a400b841ed37e2b4ecf"
-  integrity sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.3, browserslist@^4.16.6, browserslist@^4.20.2, browserslist@^4.20.3, browserslist@^4.21.3:
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
+  integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
   dependencies:
-    caniuse-lite "^1.0.30001366"
-    electron-to-chromium "^1.4.188"
+    caniuse-lite "^1.0.30001370"
+    electron-to-chromium "^1.4.202"
     node-releases "^2.0.6"
-    update-browserslist-db "^1.0.4"
+    update-browserslist-db "^1.0.5"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -3203,10 +3212,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001366:
-  version "1.0.30001367"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz#2b97fe472e8fa29c78c5970615d7cd2ee414108a"
-  integrity sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+  version "1.0.30001373"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz#2dc3bc3bfcb5d5a929bec11300883040d7b4b4be"
+  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3358,9 +3367,9 @@ cli-highlight@^2.1.10:
     yargs "^16.0.0"
 
 cli-spinners@^2.5.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
-  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
 cli-table3@~0.6.1:
   version "0.6.2"
@@ -3627,17 +3636,17 @@ copy-webpack-plugin@^9.0.1:
     serialize-javascript "^6.0.0"
 
 core-js-compat@^3.21.0, core-js-compat@^3.22.1, core-js-compat@^3.8.3:
-  version "3.23.5"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.23.5.tgz#11edce2f1c4f69a96d30ce77c805ce118909cd5b"
-  integrity sha512-fHYozIFIxd+91IIbXJgWd/igXIc8Mf9is0fusswjnGIWVG96y2cwyUdlCkGOw6rMLHKAxg7xtCIVaHsyOUnJIg==
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.24.1.tgz#d1af84a17e18dfdd401ee39da9996f9a7ba887de"
+  integrity sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==
   dependencies:
-    browserslist "^4.21.2"
+    browserslist "^4.21.3"
     semver "7.0.0"
 
 core-js@^3.23.5, core-js@^3.8.3:
-  version "3.23.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.5.tgz#1f82b0de5eece800827a2f59d597509c67650475"
-  integrity sha512-7Vh11tujtAZy82da4duVreQysIoO2EvVrur7y6IzZkH1IHPSekuDi8Vuw1+YKjkbfWLRD7Nc9ICQ/sIUDutcyg==
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.24.1.tgz#cf7724d41724154010a6576b7b57d94c5d66e64f"
+  integrity sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -3847,9 +3856,9 @@ csstype@^2.6.8:
   integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
 
 cypress@^10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
-  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.4.0.tgz#bb5b3b6588ad49eff172fecf5778cc0da2980e4e"
+  integrity sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -4414,10 +4423,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.188:
-  version "1.4.195"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.195.tgz#139b2d95a42a3f17df217589723a1deac71d1473"
-  integrity sha512-vefjEh0sk871xNmR5whJf9TEngX+KTKS3hOHpjoMpauKkwlGwtMz1H8IaIjAT/GNnX0TbGwAdmVoXCAzXf+PPg==
+electron-to-chromium@^1.4.202:
+  version "1.4.208"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz#ecb5b47c8cc212a43172ffc5ce50178a638a5d74"
+  integrity sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ==
 
 emittery@^0.10.2:
   version "0.10.2"
@@ -4456,7 +4465,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.9.3:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
   integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
@@ -4592,9 +4601,9 @@ eslint-plugin-prettier@^4.2.1:
     prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-vue@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-9.2.0.tgz#b7ca02b2ce8218b7586346440fc61c2655db353a"
-  integrity sha512-W2hc+NUXoce8sZtWgZ45miQTy6jNyuSdub5aZ1IBune4JDeAyzucYX0TzkrQ1jMO52sNUDYlCIHDoaNePe0p5g==
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-9.3.0.tgz#c3f5ce515dae387e062428725c5cf96098d9da0b"
+  integrity sha512-iscKKkBZgm6fGZwFt6poRoWC0Wy2dQOlwUPW++CiPoQiw1enctV2Hj5DBzzjJZfyqs+FAXhgzL4q0Ww03AgSmQ==
   dependencies:
     eslint-utils "^3.0.0"
     natural-compare "^1.4.0"
@@ -4658,12 +4667,13 @@ eslint-webpack-plugin@^3.1.0:
     schema-utils "^4.0.0"
 
 eslint@^8.20.0:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.20.0.tgz#048ac56aa18529967da8354a478be4ec0a2bc81b"
-  integrity sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.21.0.tgz#1940a68d7e0573cef6f50037addee295ff9be9ef"
+  integrity sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==
   dependencies:
     "@eslint/eslintrc" "^1.3.0"
-    "@humanwhocodes/config-array" "^0.9.2"
+    "@humanwhocodes/config-array" "^0.10.4"
+    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -4673,14 +4683,17 @@ eslint@^8.20.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.3.2"
+    espree "^9.3.3"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
     functional-red-black-tree "^1.0.1"
     glob-parent "^6.0.1"
     globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -4698,12 +4711,12 @@ eslint@^8.20.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.3.1, espree@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
-  integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
+espree@^9.3.1, espree@^9.3.2, espree@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
+  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
   dependencies:
-    acorn "^8.7.1"
+    acorn "^8.8.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
@@ -4757,9 +4770,9 @@ event-pubsub@4.3.0:
   integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
 
 eventemitter2@^6.4.3:
-  version "6.4.6"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.6.tgz#92d56569cc147a4d9b9da9e942e89b20ce236b0a"
-  integrity sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -5058,6 +5071,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -5314,9 +5335,9 @@ globals@^11.1.0, globals@^11.12.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.15.0:
-  version "13.16.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.16.0.tgz#9be4aca28f311aaeb974ea54978ebbb5e35ce46a"
-  integrity sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==
+  version "13.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
+  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
   dependencies:
     type-fest "^0.20.2"
 
@@ -5336,6 +5357,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 graphql@^16.3.0:
   version "16.5.0"
@@ -6876,6 +6902,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7685,12 +7718,26 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map@^4.0.0:
   version "4.0.0"
@@ -8610,9 +8657,9 @@ sass-loader@^13.0.2:
     neo-async "^2.6.2"
 
 sass@^1.53.0:
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.53.0.tgz#eab73a7baac045cc57ddc1d1ff501ad2659952eb"
-  integrity sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.54.0.tgz#24873673265e2a4fe3d3a997f714971db2fba1f4"
+  integrity sha512-C4zp79GCXZfK0yoHZg+GxF818/aclhp9F48XBu/+bm9vXEVAYov9iU3FBVRMq3Hx3OA4jfKL+p2K9180mEh0xQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -8746,9 +8793,9 @@ serve-static@1.15.0:
     send "0.18.0"
 
 set-cookie-parser@^2.4.6:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz#96b59525e1362c94335c3c761100bb6e8f2da4b0"
-  integrity sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz#ddd3e9a566b0e8e0862aca974a6ac0e01349430b"
+  integrity sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -9567,7 +9614,7 @@ untildify@^4.0.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
-update-browserslist-db@^1.0.4:
+update-browserslist-db@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
   integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
@@ -9680,9 +9727,9 @@ vinyl@^2.2.1:
     replace-ext "^1.0.0"
 
 vue-demi@*:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.5.tgz#d5eddbc9eaefb89ce5995269d1fa6b0486312092"
-  integrity sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.6.tgz#f9433cbd75e68a970dec066647f4ba6c08ced48f"
+  integrity sha512-02NYpxgyGE2kKGegRPYlNQSL1UWfA/+JqvzhGCOYjhfbLWXU5QQX0+9pAm/R2sCOPKr5NBxVIab7fvFU0B1RxQ==
 
 vue-eslint-parser@^9.0.0, vue-eslint-parser@^9.0.1:
   version "9.0.3"
@@ -9717,9 +9764,9 @@ vue-loader@^17.0.0:
     loader-utils "^2.0.0"
 
 vue-router@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.1.2.tgz#ae08f63c9610afa6bff6743e8f128b7054d4c9f5"
-  integrity sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.1.3.tgz#f8dc7931a2253cc5aa9b740f8b98969d08ca283c"
+  integrity sha512-XvK81bcYglKiayT7/vYAg/f36ExPC4t90R/HIpzrZ5x+17BOWptXLCrEPufGgZeuq68ww4ekSIMBZY1qdUdfjA==
   dependencies:
     "@vue/devtools-api" "^6.1.4"
 
@@ -9737,9 +9784,9 @@ vue-template-es2015-compiler@^1.9.0:
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
 vue-tippy@^6.0.0-alpha.62:
-  version "6.0.0-alpha.62"
-  resolved "https://registry.yarnpkg.com/vue-tippy/-/vue-tippy-6.0.0-alpha.62.tgz#1bd6d70ee8b07fb11cb816d92b6cc72db61834b1"
-  integrity sha512-Q+Dn7D3tJq0w9HSWbxAexZ9LaP96Kg0dK8ridBKNsgcRBtYHJcaP4TqA/qSl5HbEv7bcD7dqQ4Q9zndMKkE4mw==
+  version "6.0.0-alpha.63"
+  resolved "https://registry.yarnpkg.com/vue-tippy/-/vue-tippy-6.0.0-alpha.63.tgz#9de5967ced0cd8b8261d60e85b5bd9b6d2f940e7"
+  integrity sha512-TT7Jq9rg2O5c/wFn4Wuyn300k1aUwXvl93Sy0YBdlspoUh1bO5B2OEJKaZ8R4UTH/4CUIGuTjNJPwAHyQ/4BqQ==
   dependencies:
     tippy.js "^6.3.7"
 
@@ -9782,7 +9829,7 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.12"
 
-watchpack@^2.3.1:
+watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -9916,20 +9963,20 @@ webpack-virtual-modules@^0.4.2:
   integrity sha512-h9atBP/bsZohWpHnr+2sic8Iecb60GxftXsWNLLLSqewgIsGzByd2gcIID4nXcG+3tNe4GQG3dLcff3kXupdRA==
 
 webpack@^5.54.0:
-  version "5.73.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.73.0.tgz#bbd17738f8a53ee5760ea2f59dce7f3431d35d38"
-  integrity sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.9.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -9942,7 +9989,7 @@ webpack@^5.54.0:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
@@ -10174,6 +10221,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yorkie@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
closes monarch-initiative/monarch-api#87 

- add mock service worker to git ignore. this file is automatically created when building the app for testing. this allows us to remove the msw exceptions from prettier and eslint.
- update readme
- make new component for linking to node with adding to breadcrumbs
- update flex component
- allow pushing state with link component
- autoselect first option in single select component
- global variable for breadcrumbs list
- conditionally import msw so it doesn't get included in production build
- get rid of set/get route data hack. replace with new vue-router capability to set history state on push/replace
- for popular node searches, only show those that have been searched 3 or more times
- for "send to phenotype explorer" button in text annotator mode, use anchor instead of button and stringify data
- use breadcrumb links for association and evidence tables
- refactor node page association section watchers to fix regression bug (couldn't go backward in browser history stack without erasing forward entries)
- add breadcrumbs section that displays breadcrumbs global variable, with clear button
- json parse/stringify util funcs
- add test for breadcrumbs
- add some customized labels to node page fixture data