### PR TITLE
Remove linkedin links

### DIFF
--- a/src/views/about/PageSources.vue
+++ b/src/views/about/PageSources.vue
@@ -152,7 +152,7 @@ function getSrc(image = "") {
     if (image.startsWith("http")) return image;
     else return require(`@/assets/sources/${image}`);
   } catch (error) {
-    return false;
+    return "";
   }
 }
 

--- a/src/views/about/PageTeam.vue
+++ b/src/views/about/PageTeam.vue
@@ -115,12 +115,12 @@ type Team = Array<{
 
 const team = teamData as Team;
 
-/** get group img src with fallback if not found */
+/** get group img src */
 function getSrc(image: string) {
   try {
     return require(`@/assets/team/groups/${image}`);
   } catch (error) {
-    return false;
+    return "";
   }
 }
 </script>

--- a/src/views/about/team.json
+++ b/src/views/about/team.json
@@ -72,8 +72,7 @@
       },
       {
         "name": "Bryan Laraway",
-        "role": "Data Wrangler",
-        "link": "https://www.linkedin.com/in/bryanlaraway/"
+        "role": "Data Wrangler"
       }
     ]
   },
@@ -89,8 +88,7 @@
       },
       {
         "name": "Leigh Carmody",
-        "role": "Scientific Curator",
-        "link": "https://www.linkedin.com/in/leighcarmody/"
+        "role": "Scientific Curator"
       },
       {
         "name": "Hannah Blau",
@@ -126,8 +124,7 @@
       },
       {
         "name": "Nomi Harris",
-        "role": "Program Manager",
-        "link": "https://www.linkedin.com/in/nomiharris"
+        "role": "Program Manager"
       },
       {
         "name": "Sierra Taylor Moxon",
@@ -147,14 +144,12 @@
       {
         "name": "Deepak Unni",
         "role": "Bioinformatics Software Developer",
-        "alumni": true,
-        "link": "https://www.linkedin.com/in/deepakunni3"
+        "alumni": true
       },
       {
         "name": "Eric Douglass",
         "role": "Software developer",
-        "alumni": true,
-        "link": "https://www.linkedin.com/in/eric-douglass-7ba8a723/"
+        "alumni": true
       },
       {
         "name": "Sarah Kim",
@@ -170,14 +165,12 @@
       {
         "name": "Jeremy Nguyen Xuan",
         "role": "Software Engineer",
-        "alumni": true,
-        "link": "https://www.linkedin.com/in/jeremy-nguyen-xuan-84a26721/?originalSubdomain=au"
+        "alumni": true
       },
       {
         "name": "Nicole Washington",
         "role": "Lead Bioinformatician",
-        "alumni": true,
-        "link": "https://www.linkedin.com/in/nicole-l-washington/"
+        "alumni": true
       }
     ]
   },
@@ -189,13 +182,11 @@
     "members": [
       {
         "name": "Jen Martin",
-        "role": "Scientific Software Engineer",
-        "link": "https://www.linkedin.com/in/jen-martin-9b73774/"
+        "role": "Scientific Software Engineer"
       },
       {
         "name": "Tom Conlin",
-        "role": "Bioinformaticist",
-        "link": "https://www.linkedin.com/in/tomconlin/"
+        "role": "Bioinformaticist"
       },
       {
         "name": "Daniel Keith",
@@ -212,8 +203,7 @@
     "members": [
       {
         "name": "Lilly Winfree",
-        "role": "Science and Data Analyst",
-        "link": "https://www.linkedin.com/in/lilly-winfree-phd/"
+        "role": "Science and Data Analyst"
       }
     ]
   },
@@ -224,8 +214,7 @@
     "members": [
       {
         "name": "Sebastian Köhler",
-        "role": "Bioinformatician & Developer",
-        "link": "https://www.linkedin.com/in/koehlers/?originalSubdomain=de"
+        "role": "Bioinformatician & Developer"
       }
     ]
   },
@@ -241,8 +230,7 @@
       },
       {
         "name": "Jules Jacobsen",
-        "role": "Bioinformatician",
-        "link": "https://www.linkedin.com/in/julesjacobsen/?originalSubdomain=uk"
+        "role": "Bioinformatician"
       },
       {
         "name": "Tomasz Konopka",
@@ -281,8 +269,7 @@
       },
       {
         "name": "Nicolas Matentzoglu",
-        "role": "Semantic Web Developer",
-        "link": "https://www.linkedin.com/in/nmatentzoglu/?originalSubdomain=gr"
+        "role": "Semantic Web Developer"
       }
     ]
   },
@@ -294,18 +281,15 @@
     "members": [
       {
         "name": "Tudor Groza",
-        "role": "Phenomics Team Leader",
-        "link": "https://www.linkedin.com/in/tudorgroza/?originalSubdomain=au"
+        "role": "Phenomics Team Leader"
       },
       {
         "name": "Craig McNamara",
-        "role": "Developer",
-        "link": "https://www.linkedin.com/in/craig-mcnamara-565b8323/?originalSubdomain=au"
+        "role": "Developer"
       },
       {
         "name": "Edwin Zhang",
-        "role": "Developer",
-        "link": "https://www.linkedin.com/in/edwin-zhang-64280965/"
+        "role": "Developer"
       }
     ]
   },


### PR DESCRIPTION
@putmantime This PR removes LinkedIn links from the team page. 

When making the team page, I filled out as many details in `team.json` as I could I my own. I did this because I expected that it would never be completed if I asked each member to fill in their details individually. I made a mistake in that I too eagerly searched for updated photos and links for each member. Where I could not find a university profile/personal website/github/etc for a person, I used a LinkedIn if they had one. This is probably not a good idea, as you can see who visits your profile on LinkedIn, and some people may find that too personal of a thing to link to.